### PR TITLE
Support-355: Upgrade Wagtail v2.16

### DIFF
--- a/docs/support-runbook.md
+++ b/docs/support-runbook.md
@@ -1,0 +1,50 @@
+# Support runbook
+
+This document describes possible ways in which the system may fail or malfunction, with instructions how to handle and recover from these scenarios.
+
+This runbook is supplementary to the [general 24/7 support runbook](https://intranet.torchbox.com/propositions/design-and-build-proposition/delivering-projects/dedicated-support-team/247-support-out-of-hours-runbook/), with details about project-specific actions which may be necessary for troubleshooting and restoring service.
+
+See also our [incident process](https://intranet.torchbox.com/propositions/design-and-build-proposition/delivering-projects/application-support/incident-process/) if you're not already following this.
+
+**Note: Remove the above intranet references if this project will be supported by the client's team, or handed to a third party for support. Consider whether to incorporate any scenarios from the general runbook in these cases.**
+
+## Support resources
+
+- Git repositories:
+  - [Project repository]()
+  - Include repositories for other dependencies relevant to the runbook
+- [Scout APM]()
+- Papertrail logs:
+  - [Production]()
+  - [Staging]()
+- [Sentry project]()
+- S3 buckets:
+  - `project-production`
+  - `buckup-project-staging`
+- ... Any other resources useful for troubleshooting the site ...
+
+## Scenario X: [Description of overall scenario, e.g. 'Data rejected by AnnoyingService API']
+
+### 1. [Put the most important/likely thing to check first, e.g. 'Is authentication failing?']
+
+- Description of what to check (e.g. 'Does the error response mention "invalid credentials"?')
+- Could involve multiple steps (e.g. 'Manually test the credentials with this example cURL command: ...')
+
+**Action if there is an issue with [thing]**
+
+- Description of what to do (e.g. 'Reset the credentials and update the environment variables X and Y with the new details')
+- Include technical steps (if fixable), who to raise the issue with (if externally-managed), any specific instructions for communicating with the client
+
+### 2. [Next thing to check if first check wasn't the problem, e.g. 'Is the site posting malformed data?']
+
+...
+
+### 3. [Include as many checks as necessary to cover the possible explanations for the scenario]
+
+...
+
+## Scenario Y: [Another, separate scenario, e.g. 'Search not returning any highlighted results']
+
+...
+
+## Scenario Z: [Include as many different scenarios as necessary for known failure modes of the site]

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,28 @@
+# Upgrading guidelines
+
+This document describes aspects of the system which should be given particular attention when upgrading Wagtail or its dependencies.
+
+## Critical paths
+
+The following areas of functionality are critical paths for the site which don't have full automated tests and should be checked manually.
+
+(If this information is managed in a separate document, a link here will suffice.)
+
+### 1. [Summary of critical path, e.g. 'Donations']
+
+[Description of the overall functionality covered]
+
+- Step-by-step instructions for what to test and what the expected behaviour is
+- Include details for edge cases as well as the general case
+- Break this into separate subsections if there's a lot to cover
+- Don't include anything which is already covered by automated testing, unless it's a prerequisite for a manual test
+
+## Other considerations
+
+As well as testing the critical paths, these areas of functionality should be checked:
+
+- ...
+- Other places where you know extra maintenance or checks may be necessary
+- This could be code which you know should be checked and possibly removed - e.g. because you've patched something until a fix is merged in a subsequent release.
+- Any previous fixes which may need to be updated/reapplied on subsequent upgrades
+- Technical debt which could be affected by an upgrade.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,19 @@ dj-database-url==0.5.0
 psycopg2==2.8.6
 libsass==0.20.1
 Pillow==9.0.0
-Markdown==3.3.4
+Markdown==3.3.6
 Pygments==2.10.0
-django-compressor==2.4.1
+django-compressor==3.1
 django-libsass>=0.7
 whitenoise==5.3.0
 brotlipy==0.7.0
-django-storages==1.12.2
+django-storages==1.12.3
 boto3==1.19.4
 redis==3.5.3
 django-redis==5.0.0
-sentry-sdk==1.4.3
-scout-apm==2.23.2
-mammoth==1.4.17  # used for curstom wagtail content import parser
+sentry-sdk==1.5.3
+scout-apm==2.23.5
+mammoth==1.4.18  # used for curstom wagtail content import parser
 
 django-basic-auth-ip-whitelist==0.3.4
 django-referrer-policy==1.0
@@ -24,7 +24,7 @@ django-referrer-policy==1.0
 # wagtail packages
 wagtailaltgenerator==4.1.2
 wagtail-airtable==0.2.1
-wagtail-content-import==0.5.0
+wagtail-content-import==0.6.0
 wagtail-image-import==0.1.1
 wagtail-transfer==0.8.2
 git+https://github.com/torchbox/wagtail-ab-testing@1e959cc#egg=wagtail-ab-testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-Django==3.2.8
+Django==3.2.11
 wagtail==2.16.1
 dj-database-url==0.5.0
 psycopg2==2.8.6
 libsass==0.20.1
-Pillow==8.4.0
+Pillow==9.0.0
 Markdown==3.3.4
 Pygments==2.10.0
 django-compressor==2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,6 @@ wagtail-airtable==0.2.1
 wagtail-content-import==0.5.0
 wagtail-image-import==0.1.1
 wagtail-transfer==0.8.2
-wagtail-ab-testing==0.6
+git+https://github.com/torchbox/wagtail-ab-testing@1e959cc#egg=wagtail-ab-testing
 Wand==0.6.7
 wagtailmedia==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.11
+Django==3.2.12
 wagtail==2.16.1
 dj-database-url==0.5.0
 psycopg2==2.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.2.8
-wagtail==2.15.1
+wagtail==2.16.1
 dj-database-url==0.5.0
 psycopg2==2.8.6
 libsass==0.20.1


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/support-team/tickets/355 
From v2.15 to v2.16,

Removed support for Django 3.0 and 3.1:

The current Django version is 3.2 so it's safe

Removed support for Python 3.6:

The current Python version is 3.8 so it's safe

Deprecated sidebar capabilities:
It looks fine

StreamField ListBlock now returns ListValue rather than a list instance:
It looks fine

Change to set method on tag fields:
It looks fine

Safety Check
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| numpy                      | 1.19.5    | <1.21.0                  | 43453    |
| numpy                      | 1.19.5    | <1.22.0                  | 44716    |
| numpy                      | 1.19.5    | <1.22.0                  | 44717    |
| numpy                      | 1.19.5    | >0                       | 44715    |
+==============================================================================+

numpy is from the `wagtail-ab-testing` dependencies, but this package cannot be upgraded because 1.22 required python 3.8, and this package still uses Python 3.7
https://github.com/torchbox/wagtail-ab-testing/blob/main/setup.py#L47

NPM Audit
No package.json file found in this project