### PR TITLE
Remove the need for relative positioning causing layout issues

### DIFF
--- a/wagtailio/static/css/components/alert.scss
+++ b/wagtailio/static/css/components/alert.scss
@@ -7,7 +7,6 @@
     display: block;
     opacity: 1;
     padding: 1rem;
-    position: relative;
     z-index: 10;
   }
 

--- a/wagtailio/static/css/components/alert.scss
+++ b/wagtailio/static/css/components/alert.scss
@@ -1,13 +1,10 @@
 .alert {
-  display: none;
+  padding: 1rem;
   opacity: 0;
-  transition: opacity 1s ease;
-
+  transition: opacity 0.5s ease;
+  
   &--active {
-    display: block;
     opacity: 1;
-    padding: 1rem;
-    z-index: 10;
   }
 
   h2, h3 {

--- a/wagtailio/static/css/components/header.scss
+++ b/wagtailio/static/css/components/header.scss
@@ -4,7 +4,7 @@
 
 */
 .header {
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
   z-index: 20;

--- a/wagtailio/static/js/main.js
+++ b/wagtailio/static/js/main.js
@@ -165,9 +165,7 @@ $(function() {
     $.getJSON($alert_container.data("alert"), function(data) {
       if (data.text) {
         $alert_container.html(data.text);
-        var styles = {
-          'top': $('.header')[0].getBoundingClientRect().bottom + 'px'
-        };
+        var styles = {};
         if (data.bg_colour) {
           styles['background-color'] = '#' + data.bg_colour;
         }

--- a/wagtailio/static/js/main.js
+++ b/wagtailio/static/js/main.js
@@ -173,7 +173,7 @@ $(function() {
           styles['color'] = '#' + data.text_colour;
         }
         $alert_container.css(styles).toggleClass('alert--default', !(data.bg_colour || data.text_colour));
-        $alert_container.prop('aria-expanded', true).addClass('alert--active');
+        $alert_container.addClass('alert--active');
       }
     })
   }

--- a/wagtailio/static/js/main.js
+++ b/wagtailio/static/js/main.js
@@ -164,7 +164,8 @@ $(function() {
   if ($alert_container.data("alert")) {
     $.getJSON($alert_container.data("alert"), function(data) {
       if (data.text) {
-        $alert_container.html(data.text);
+        $alert_container.html('<aside class="alert">' + data.text + '</aside>');
+        var $aside = $alert_container.find("aside");
         var styles = {};
         if (data.bg_colour) {
           styles['background-color'] = '#' + data.bg_colour;
@@ -172,8 +173,8 @@ $(function() {
         if (data.text_colour) {
           styles['color'] = '#' + data.text_colour;
         }
-        $alert_container.css(styles).toggleClass('alert--default', !(data.bg_colour || data.text_colour));
-        $alert_container.addClass('alert--active');
+        $aside.css(styles).toggleClass('alert--default', !(data.bg_colour || data.text_colour));
+        $aside.addClass('alert--active');
       }
     })
   }

--- a/wagtailio/static/js/main.js
+++ b/wagtailio/static/js/main.js
@@ -174,7 +174,9 @@ $(function() {
           styles['color'] = '#' + data.text_colour;
         }
         $aside.css(styles).toggleClass('alert--default', !(data.bg_colour || data.text_colour));
-        $aside.addClass('alert--active');
+        setTimeout(() => {
+          $aside.addClass('alert--active');
+        }, 1);
       }
     })
   }

--- a/wagtailio/templates/base.html
+++ b/wagtailio/templates/base.html
@@ -103,6 +103,8 @@
         <![endif]-->
 
         <div class="page">
+            <div data-alert="{% url 'sitewide_alert:sitewide_alert' %}"></div>
+
             <header class="header">
                 <div class="header__container">
                     <a class="branding" href="/">
@@ -116,8 +118,6 @@
             </header> <!-- /header -->
 
             {% include "includes/svg_sprites.html" %}
-
-            <div data-alert="{% url 'sitewide_alert:sitewide_alert' %}"></div>
 
             {% block sidebar %}{% endblock %}
 

--- a/wagtailio/templates/base.html
+++ b/wagtailio/templates/base.html
@@ -117,7 +117,7 @@
 
             {% include "includes/svg_sprites.html" %}
 
-            <div class="alert" data-alert="{% url 'sitewide_alert:sitewide_alert' %}"></div>
+            <div data-alert="{% url 'sitewide_alert:sitewide_alert' %}"></div>
 
             {% block sidebar %}{% endblock %}
 

--- a/wagtailio/templates/base.html
+++ b/wagtailio/templates/base.html
@@ -117,7 +117,7 @@
 
             {% include "includes/svg_sprites.html" %}
 
-            <div class="alert" data-alert="{% url 'sitewide_alert:sitewide_alert' %}" aria-expanded="false"></div>
+            <div class="alert" data-alert="{% url 'sitewide_alert:sitewide_alert' %}"></div>
 
             {% block sidebar %}{% endblock %}
 


### PR DESCRIPTION
#147 with extra front-end tweaks. The alert itself looks the same, I just fixed the issues I reported in #147, fixed the animation, and moved it to be above the header.

If we want to move it below the header again, it’s just a matter of moving the element back to where it was before.

![sitewide](https://user-images.githubusercontent.com/877585/156468565-97426a12-e8b0-408d-bd75-33ed97c738d9.gif)

