### PR TITLE
Modify the API to serve content from AreWeHeadlessYet site

### DIFF
--- a/wagtailio/api.py
+++ b/wagtailio/api.py
@@ -11,14 +11,13 @@ class AreWeHeadlessYetPagesAPIViewSet(PagesAPIViewSet):
     def get_base_queryset(self):
         """Returns a queryset containing only pages from the AreWeHeadLessYet site."""
 
-        areweheadlessyet_queryset = AreWeHeadlessYetHomePage.objects.all()
-        if not areweheadlessyet_queryset:
-            return areweheadlessyet_queryset
-
-        areweheadlessyet_root_page = areweheadlessyet_queryset[0]
-        return Page.objects.live().descendant_of(
-            areweheadlessyet_root_page, inclusive=True
-        )
+        areweheadlessyet_root_page = AreWeHeadlessYetHomePage.objects.first()
+        if areweheadlessyet_root_page:
+            return Page.objects.live().descendant_of(
+                areweheadlessyet_root_page, inclusive=True
+            )
+        else:
+            return Page.objects.none()
 
 
 api_router.register_endpoint("pages", AreWeHeadlessYetPagesAPIViewSet)

--- a/wagtailio/api.py
+++ b/wagtailio/api.py
@@ -1,8 +1,24 @@
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.api.v2.views import PagesAPIViewSet
-from wagtail.images.api.v2.views import ImagesAPIViewSet
+from wagtail.core.models import Page
+
+from wagtailio.areweheadlessyet.models import AreWeHeadlessYetHomePage
 
 api_router = WagtailAPIRouter("wagtailapi")
 
-api_router.register_endpoint("pages", PagesAPIViewSet)
-api_router.register_endpoint("images", ImagesAPIViewSet)
+
+class AreWeHeadlessYetPagesAPIViewSet(PagesAPIViewSet):
+    def get_base_queryset(self):
+        """Returns a queryset containing only pages from the AreWeHeadLessYet site."""
+
+        areweheadlessyet_queryset = AreWeHeadlessYetHomePage.objects.all()
+        if not areweheadlessyet_queryset:
+            return areweheadlessyet_queryset
+
+        areweheadlessyet_root_page = areweheadlessyet_queryset[0]
+        return Page.objects.live().descendant_of(
+            areweheadlessyet_root_page, inclusive=True
+        )
+
+
+api_router.register_endpoint("pages", AreWeHeadlessYetPagesAPIViewSet)


### PR DESCRIPTION
**Context**

We want to query data from the AreWeHeadlessYet site using the API. However, we can't use the `areweheadlessyet.wagtail.org` domain for the  AreWeHeadlessYet site/backend because it's already used for the Next.js frontend hosted in Vercel.

**Solution**

Use the `wagtail.org` domain to serve content from the AreWeHeadlessYet site/backend - that is the goal of this PR.
