### PR TITLE
Support-355: Upgrade Wagtail v2.16 (revised)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ wagtail==2.16.1
 dj-database-url==0.5.0
 psycopg2==2.8.6
 libsass==0.20.1
-Pillow==9.0.0
+Pillow==9.0.1
 Markdown==3.3.6
 Pygments==2.10.0
 django-compressor==3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,22 @@
-Django==3.2.8
-wagtail==2.15.1
+Django==3.2.12
+wagtail==2.16.1
 dj-database-url==0.5.0
 psycopg2==2.8.6
 libsass==0.20.1
-Pillow==8.4.0
-Markdown==3.3.4
+Pillow==9.0.0
+Markdown==3.3.6
 Pygments==2.10.0
-django-compressor==2.4.1
+django-compressor==3.1
 django-libsass>=0.7
 whitenoise==5.3.0
 brotlipy==0.7.0
-django-storages==1.12.2
+django-storages==1.12.3
 boto3==1.19.4
 redis==3.5.3
 django-redis==5.0.0
-sentry-sdk==1.4.3
-scout-apm==2.23.2
-mammoth==1.4.17  # used for curstom wagtail content import parser
+sentry-sdk==1.5.3
+scout-apm==2.23.5
+mammoth==1.4.18  # used for curstom wagtail content import parser
 
 django-basic-auth-ip-whitelist==0.3.4
 django-referrer-policy==1.0
@@ -24,9 +24,9 @@ django-referrer-policy==1.0
 # wagtail packages
 wagtailaltgenerator==4.1.2
 wagtail-airtable==0.2.1
-wagtail-content-import==0.5.0
+wagtail-content-import==0.6.0
 wagtail-image-import==0.1.1
 wagtail-transfer==0.8.2
-wagtail-ab-testing==0.6
+wagtail-ab-testing==0.7
 Wand==0.6.7
 wagtailmedia==0.8.0


### PR DESCRIPTION
Based on https://github.com/wagtail/wagtail.org/pull/144 with the following changes:

- No docs added, as requested
- `wagtail-ab-testing` dependency updated to use the 0.7 release rather than targeting a commit hash
- `pillow` dependency updated for the recent security release