### PR TITLE
Align text to be centered in sitewide setting

### DIFF
--- a/wagtailio/static/css/components/alert.scss
+++ b/wagtailio/static/css/components/alert.scss
@@ -2,7 +2,8 @@
   padding: 1rem;
   opacity: 0;
   transition: opacity 0.5s ease;
-  
+  text-align: center;
+
   &--active {
     opacity: 1;
   }


### PR DESCRIPTION
Simply centers the text in the sitewide setting for a small aesthetic update. 

Screenshot below:
![image](https://user-images.githubusercontent.com/4743971/165594404-99127cd3-6b59-4a04-876c-a842f9c15361.png)
