### PR TITLE
Adding email notification setting to stop spamming superusers.

### DIFF
--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -311,6 +311,9 @@ if "EMAIL_SUBJECT_PREFIX" in env:
 if "SERVER_EMAIL" in env:
     SERVER_EMAIL = DEFAULT_FROM_EMAIL = env["SERVER_EMAIL"]
 
+# Notification emails
+
+WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = False
 
 # Security configuration
 # https://docs.djangoproject.com/en/stable/ref/middleware/#module-django.middleware.security


### PR DESCRIPTION
Hello. I would like to add this setting so that our admins don't have to receive every moderation email that comes through. As we start publishing more blogs and content, the amount of email is going to get annoying.

Please let me know if there are any drawbacks I'm not aware of.