### PR TITLE
Move deploy signal handler outside function to avoid it being garbage collected

### DIFF
--- a/wagtailio/areweheadlessyet/signal_handlers.py
+++ b/wagtailio/areweheadlessyet/signal_handlers.py
@@ -6,20 +6,10 @@ from .models import AreWeHeadlessYetHomePage, AreWeHeadlessYetTopicPage
 
 
 def register_signal_handlers():
-    deploy_url = getattr(settings, "VERCEL_DEPLOY_HOOK_URL", None)
-    if not deploy_url:
+    if not getattr(settings, "VERCEL_DEPLOY_HOOK_URL", None):
         return
 
-    from .thread_pool import run_in_thread_pool
-
-    @run_in_thread_pool
-    def deploy(sender, **kwargs):
-        """Triggers a build on Vercel."""
-
-        try:
-            requests.post(deploy_url, timeout=settings.VERCEL_DEPLOY_REQUEST_TIMEOUT)
-        except requests.exceptions.Timeout:
-            pass  # Ignore this error
+    from .thread_pool import deploy
 
     page_published.connect(deploy, sender=AreWeHeadlessYetHomePage)
     page_published.connect(deploy, sender=AreWeHeadlessYetTopicPage)

--- a/wagtailio/areweheadlessyet/thread_pool.py
+++ b/wagtailio/areweheadlessyet/thread_pool.py
@@ -26,3 +26,16 @@ def run_in_thread_pool(function):
         thread_pool.send((function, args, kwargs))
 
     return decorator
+
+
+@run_in_thread_pool
+def deploy(sender, **kwargs):
+    """Triggers a build on Vercel."""
+
+    try:
+        requests.post(
+            settings.VERCEL_DEPLOY_HOOK_URL,
+            timeout=settings.VERCEL_DEPLOY_REQUEST_TIMEOUT,
+        )
+    except requests.exceptions.Timeout:
+        pass  # Ignore this error


### PR DESCRIPTION
We were having an issue with the automatic deploy hook as it seemed that the signal listeners 'weren't listening'.

This happened because the `deploy` function was defined inside another function. Thus, no other part of the program references it once that function is run. However, signal listeners are weakly referenced hence the 'bug'.

I changed the `deploy` function to be a global one.