### PR TITLE
Heroku troubleshoot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,13 @@ CMD gunicorn wagtailio.wsgi:application
 
 FROM backend AS dev
 
+# Install Node.js because newer versions of Heroku CLI have a node binary dependency
+
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+RUN apt-get install -y nodejs
+
 # Install Heroku CLI
-RUN curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
+RUN curl https://cli-assets.heroku.com/install.sh | sh
 
 # Install AWS CLI
 RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip" && \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run the following command to start the Docker containers:
 make start
 ```
 
-Then, to start the development server, run:
+Then, to start the development server, open a new terminal window and run:
 
 ```
 make runserver


### PR DESCRIPTION
I was receiving an error message related to Heroku CLI when attempting to install the local environment on Docker. The message stated "Unable to locate package heroku" and prevented the build from finishing. 

@Tijani-Dia suggested using the command `curl https://cli-assets.heroku.com/install.sh | sh` instead and that returned the error "Error: node is not installed."

It seems that the included node binary in the Heroku CLI package does not work on the Python 3.8:bullseye and requires nodejs to be installed as a fallback. Adding node only to make the Heroku CLI function doesn't strike me as an ideal solution but I'm not sure what other option we can use if the package for our operating system of choice cannot be found using the original Heroku CLI installation script unless we want to remove the CLI from the configuration entirely.

Please let me know if there are any improvements I can make.