### PR TITLE
Adjusted display settings to prevent image overflow in textimage blocks

### DIFF
--- a/wagtailio/static/css/components/text-image.scss
+++ b/wagtailio/static/css/components/text-image.scss
@@ -14,15 +14,27 @@
   .container {
     max-width: 800px;
     margin: 0 auto;
+    overflow: hidden;
 
     .text {
       max-width: 50%;
+
+      @include media-query(mobileOnly) {
+        max-width: 100%;
+        padding-top: 50px;
+      }
     }
 
     .image {
       float: right;
       max-width: 50%;
       padding-left: $gutter;
+
+      @include media-query(mobileOnly){
+        max-width: 100%;
+        padding-left: 0px;
+        float: none;
+      }
 
       img {
         display: block;


### PR DESCRIPTION
Images were overflowing from the textimage blocks and were displaying poorly in mobile. I changed the overflow settings and added some media queries to make these blocks display better. Please let me know if you have any suggested changes.