### PR TITLE
Remove code-highlighting css link from Blog

### DIFF
--- a/wagtailio/blog/templates/blog/blog_index_page.html
+++ b/wagtailio/blog/templates/blog/blog_index_page.html
@@ -3,7 +3,6 @@
 {% load static wagtailcore_tags wagtailadmin_tags wagtailimages_tags wagtailio_utils %}
 
 {% block body_class %}template-blog{% endblock %}
-{% block extra_css %}<link rel="stylesheet" href="{% static 'css/vendor/code-highlighting.css' %}" />{% endblock %}
 
 {% block content %}
     <div class="page-content">

--- a/wagtailio/blog/templates/blog/blog_page.html
+++ b/wagtailio/blog/templates/blog/blog_page.html
@@ -3,7 +3,6 @@
 {% load static wagtailcore_tags wagtailadmin_tags wagtailimages_tags wagtailio_utils %}
 
 {% block body_class %}template-blog{% endblock %}
-{% block extra_css %}<link rel="stylesheet" href="{% static 'css/vendor/code-highlighting.css' %}" />{% endblock %}
 
 {% block content %}
     <div class="page-content">


### PR DESCRIPTION
Removes references to `vendor/code-highlighting.css` as the design has updated for how these will look 