### PR TITLE
Add python test job to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,39 @@ jobs:
         run: npm ci --no-audit
       - run: npm run lint
       - run: npm run build:prod
+  test_python:
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: wagtailio.settings.production
+      DATABASE_URL: postgres://postgres:postgres@localhost/postgres
+      SECRET_KEY: iamnotsosecret
+      ALLOWED_HOSTS: localhost
+      COMPUTER_VISION_API_KEY: fake
+      COMPUTER_VISION_REGION: fake
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgress
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+          cache: 'pip'
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: System checks
+        run: python manage.py check
+      - name: Missing migrations
+        run: python manage.py makemigrations --check --noinput
+      - name: Test
+        run: python manage.py test


### PR DESCRIPTION
This picks up from 2190d16c41a3e7b628ab831795150135957a2c98 and adds an additional backend job which, for now

- runs system checks
- checks for missing migrations
- runs test suite

Future:
- add linting (black, flake8, isort)