### PR TITLE
Standalone Quote

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/quotes/standalone_quote_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/quotes/standalone_quote_block.html
@@ -1,11 +1,16 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
-<div>
-    <div>{{ value.quote }}</div>
-    <div>
+<figure class="standalone-quote grid">
+    <svg class="standalone-quote__icon" aria-hidden="true">
+        <use xlink:href="#quotes" />
+    </svg>
+    <blockquote class="standalone-quote__text heading-three">
+        <p>&ldquo;{{ value.quote }}&rdquo;</p>
+    </blockquote>
+    <figcaption class="standalone-quote__meta">
         {% if value.author_image %}
-            {% image value.author_image fill-100x100 %}
+            {% image value.author_image fill-40x40 class="standalone-quote__image" %}
         {% endif %}
-        <span>{{ value.author }}</span>
-    </div>
-</div>
+        <p class="mini-meta">{{ value.author }}</p>
+    </figcaption>
+</figure>

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/quotes/standalone_quote_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/quotes/standalone_quote_block.html
@@ -11,6 +11,6 @@
         {% if value.author_image %}
             {% image value.author_image fill-40x40 class="standalone-quote__image" %}
         {% endif %}
-        <p class="mini-meta">{{ value.author }}</p>
+        <div class="mini-meta">{{ value.author|richtext }}</div>
     </figcaption>
 </figure>

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/quotes/standalone_quote_block.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/quotes/standalone_quote_block.yaml
@@ -1,7 +1,8 @@
 context:
   value:
     quote: If I could turn one piece of code into a human and marry it, it would be the WagtailCMS StreamField
-    author: Donald Knuth - @wagtail
+    author: |
+      Donald Knuth - <b>@wagtail</b>
     author_image: fake
 
 tags:

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/quotes/standalone_quote_block.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/quotes/standalone_quote_block.yaml
@@ -1,11 +1,11 @@
 context:
   value:
-    quote: premature optimization is the root of all evil (or at least most of it) in programming
-    author: <p><a href="https://en.wikipedia.org/wiki/Donald_Knuth">Donald Knuth</a></p>
+    quote: If I could turn one piece of code into a human and marry it, it would be the WagtailCMS StreamField
+    author: Donald Knuth - @wagtail
     author_image: fake
 
 tags:
   image:
-    value.author_image fill-100x100:
+    value.author_image fill-40x40 class="standalone-quote__image":
       raw: |
-        <img src="https://via.placeholder.com/100x100" alt="Some alt">
+        <img src="https://via.placeholder.com/40x40" alt="Some alt" class="standalone-quote__image">

--- a/wagtailio/static/sass/base/_typography.scss
+++ b/wagtailio/static/sass/base/_typography.scss
@@ -111,6 +111,11 @@ h4,
     font-size: 0.875rem;
     line-height: 1.3125rem;
 
+    @include media-query(large) {
+        font-size: 0.7rem;
+        line-height: 1.05rem;
+    }
+
     &--bold {
         font-weight: $weight--bold;
     }

--- a/wagtailio/static/sass/components/_standalone-quote.scss
+++ b/wagtailio/static/sass/components/_standalone-quote.scss
@@ -1,0 +1,61 @@
+.standalone-quote {
+    align-items: center;
+    margin-bottom: 50px;
+
+    @include media-query(medium) {
+        margin-bottom: 100px;
+    }
+
+    @include media-query(large) {
+        margin-bottom: 150px;
+    }
+
+    &__icon {
+        display: none;
+
+        @include media-query(medium) {
+            width: 100%;
+            padding: 0 40px;
+            display: block;
+            grid-column: 2 / span 1;
+        }
+
+        @include media-query(large) {
+            padding: 0 20px;
+        }
+    }
+
+    &__text {
+        margin: 0;
+        grid-column: 2 / span 2;
+
+        @include media-query(medium) {
+            grid-column: 3 / span 2;
+        }
+
+        @include media-query(large) {
+            grid-column: 3 / span 3;
+        }
+    }
+
+    &__meta {
+        display: flex;
+        align-items: center;
+        margin-top: 10px;
+        grid-column: 2 / span 2;
+
+        @include media-query(medium) {
+            grid-column: 3 / span 2;
+        }
+
+        @include media-query(large) {
+            grid-column: 3 / span 3;
+        }
+    }
+
+    &__image {
+        border-radius: 50%;
+        flex-shrink: 0;
+        margin-right: 10px;
+    }
+}

--- a/wagtailio/static/sass/main.scss
+++ b/wagtailio/static/sass/main.scss
@@ -23,6 +23,7 @@
 @import 'components/icon-bullets';
 @import 'components/meta';
 @import 'components/rich-text';
+@import 'components/standalone-quote';
 @import 'components/teaser';
 
 // Atoms


### PR DESCRIPTION
Adds the FE for standalone quote component viewable [in the pattern library here](http://localhost:8000/pattern-library/render-pattern/patterns/components/streamfields/quotes/standalone_quote_block.html). The icon will need refactoring once https://github.com/wagtail/wagtail.org/pull/195 is in.

Also:
- Fixes font size of `mini-meta` above large breakpoint. It should be 14px across all breakpoints.