### PR TITLE
Blog Page

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/_pattern_library_only/blog_page_example.html
+++ b/wagtailio/project_styleguide/templates/patterns/_pattern_library_only/blog_page_example.html
@@ -1,0 +1,2 @@
+{% include "patterns/_pattern_library_only/rich_text_example.html" %}
+{% include "patterns/components/streamfields/cta/cta.html" %}

--- a/wagtailio/project_styleguide/templates/patterns/_pattern_library_only/rich_text_example.html
+++ b/wagtailio/project_styleguide/templates/patterns/_pattern_library_only/rich_text_example.html
@@ -1,0 +1,23 @@
+<div class="rich-text">
+    <h2>A quick review of traditional vs. headless Wagtail</h2>
+    <p>In a traditional Wagtail website, almost all the technology you need to make the website work lives on a single server. In this one-server-to-rule-them-all structure, the database that houses your content, the stylesheets that make your website look pretty, the ecommerce code that lets users buy things or make donations, and the rest of the code that makes your website work is all in one place.</p>
+    <p>Headless Wagtail is set up like a jamstack. In a jamstack, the backend (things like the database and the editor where you make changes to your content) is separated from the frontend (things like styles that affect how your website looks and the forms users use to make purchases or update data) and other services (like authentication or ecommerce) that make your site run. Of the headless Wagtail setups that have been created so far, typically the CMS portion of Wagtail and the database are hosted on one server, the frontend portion of the website is hosted on another server, and there's an API that connects the two parts together that lets the frontend pull content and data from the backend.</p>
+    <h3>Who uses Headless Wagtail right now?</h3>
+    <p>Currently, there are governments, nonprofits, and publications using Headless Wagtail. Here are some examples you can explore:</p>
+    <ul>
+    <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
+    <li><a href="#">Gothamist</a></li>
+    <li><a href="#">M + Museum</a></li>
+    <li><a href="#">New York Public Radio</a></li>
+    </ul>
+    <p>There are also developers who've released experimental templates for Headless Wagtail and other projects. Here are two examples from GitHub:</p>
+    <ul>
+    <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
+    <li><a href="#">Gothamist</a></li>
+    </ul>
+    <h3>Upsides to Headless Wagtail</h3>
+    <h4>You can do more with your content</h4>
+    <p>With your content API, you can reuse the same content in multiple frontends. For example, the same blog content can feed into a website, a mobile app, and apps for devices like smartwatches.</p>
+    <h4>You don't have to do everything in Django and Wagtail</h4>
+    <p>Django is an incredibly powerful web framework, and there's very little you can't do in Django or Wagtail. But Headless Wagtail gives you more options to incorporate technologies that don't run on Python. For example, JavaScript-only frontends like Next.js or Gatsby, can be very cheap to host, and a headless structure can give you the option to experiment with those or other hosting arrangements.</p>
+</div>

--- a/wagtailio/project_styleguide/templates/patterns/_pattern_library_only/rich_text_example.html
+++ b/wagtailio/project_styleguide/templates/patterns/_pattern_library_only/rich_text_example.html
@@ -5,15 +5,15 @@
     <h3>Who uses Headless Wagtail right now?</h3>
     <p>Currently, there are governments, nonprofits, and publications using Headless Wagtail. Here are some examples you can explore:</p>
     <ul>
-    <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
-    <li><a href="#">Gothamist</a></li>
-    <li><a href="#">M + Museum</a></li>
-    <li><a href="#">New York Public Radio</a></li>
+        <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
+        <li><a href="#">Gothamist</a></li>
+        <li><a href="#">M + Museum</a></li>
+        <li><a href="#">New York Public Radio</a></li>
     </ul>
     <p>There are also developers who've released experimental templates for Headless Wagtail and other projects. Here are two examples from GitHub:</p>
     <ul>
-    <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
-    <li><a href="#">Gothamist</a></li>
+        <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
+        <li><a href="#">Gothamist</a></li>
     </ul>
     <h3>Upsides to Headless Wagtail</h3>
     <h4>You can do more with your content</h4>

--- a/wagtailio/project_styleguide/templates/patterns/components/meta/meta.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/meta/meta.html
@@ -4,10 +4,10 @@
             {% include "patterns/components/icon/icon.html" with icon=value.meta_icon classes="meta__icon" %}
         {% endif %}
 
-        <p class="mini-meta mini-meta--bold">{{ value.meta_text }}</p>
+        <p class="meta__text mini-meta mini-meta--bold">{{ value.meta_text }}</p>
 
         {% if value.publication_date %}
-            <p class="mini-meta mini-meta">{{ value.publication_date|date:"j M Y" }}</p>
+            <p class="meta__date mini-meta mini-meta">{{ value.publication_date|date:"j M Y" }}</p>
         {% endif %}
     </div>
 {% endif %}

--- a/wagtailio/project_styleguide/templates/patterns/components/related-content/related-content.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/related-content/related-content.html
@@ -1,0 +1,13 @@
+{% if related_pages %}
+    <div class="related-content grid">
+        <h3 class="related-content__heading">You might also like</h3>
+
+        <div class="related-content__items">
+            {% for related in related_pages %}
+                <article class="related-content__item">
+                    {% include "patterns/components/streamfields/cards/logo_card_block.html" with value=related classes="logo-card--article" %}
+                </article>
+            {% endfor %}
+        </div>
+    </div>
+{% endif %}

--- a/wagtailio/project_styleguide/templates/patterns/components/related-content/related-content.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/components/related-content/related-content.yaml
@@ -1,0 +1,22 @@
+context:
+  related_pages:
+    - heading: Preparations for Wagtail Space NL are in full swing
+      description: The preparations for Wagtail Space NL are going great. I want to inform you about the latest developments.
+      meta_icon: arrows
+      meta_text: Community
+      logo: fake
+      link_url: '#'
+      author: John Smith
+    - heading: How to try Wagtail CMS without coding
+      description: How to setup Wagtail and explore the content management system without any coding.
+      meta_icon: location-pin
+      meta_text: Resources
+      logo: fake
+      link_url: '#'
+      author: John Smith
+
+tags:
+  image:
+    value.logo fill-40x40 class="logo-card__image":
+      raw: |
+        <img src="https://placehold.co/40x40" alt="Some alt" class="logo-card__image">

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_card_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_card_block.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 {% if value.link_url %}
-    <a href="{{ value.link_url }}" class="logo-card">
+    <a href="{{ value.link_url }}" class="logo-card {% if classes %}{{ classes }}{% endif %}">
 {% else %}
     <div class="logo-card">
 {% endif %}
@@ -12,9 +12,15 @@
     <div class="logo-card__description">{{ value.description|richtext }}</div>
 {% endif %}
 
-{% if value.logo %}
+{% if value.author and value.logo %}
+    <div class="logo-card__author-wrap">
+        {% image value.logo fill-40x40 class="logo-card__image" %}
+        <p class="logo-card__author mini-meta">{{ value.author }}</p>
+    </div>
+{% elif value.logo %}
     {% image value.logo fill-140x90 class="logo-card__image" %}
 {% endif %}
+
 {% if value.link_url %}
     </a>
 {% else %}

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
@@ -1,0 +1,1 @@
+{% extends "patterns/base_page.html" %}

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
@@ -1,1 +1,21 @@
 {% extends "patterns/base_page.html" %}
+
+{% block content %}
+    <article class="blog">
+        {# Header #}
+        <header class="grid">
+            {% include "patterns/components/meta/meta.html" with classes="blog__meta" %}
+
+            <h1 class="blog__heading article-heading">{{ page.title }}</h1>
+
+            <h2 class="blog__intro intro-small">{{ page.intro }}</h2>
+
+            {% include "patterns/components/author/author.html" with classes="blog__author author--blog" %}
+        </header>
+
+        {# Body Content #}
+
+    </article>
+
+    {# Related articles #}
+{% endblock %}

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
@@ -1,20 +1,28 @@
 {% extends "patterns/base_page.html" %}
+{% load wagtailcore_tags %}
 
 {% block content %}
     <article class="blog">
         {# Header #}
-        <header class="grid">
+        <header class="blog__header grid">
             {% include "patterns/components/meta/meta.html" with classes="blog__meta" %}
 
             <h1 class="blog__heading article-heading">{{ page.title }}</h1>
 
-            <h2 class="blog__intro intro-small">{{ page.intro }}</h2>
+            {% if page.intro %}
+                <h2 class="blog__intro intro-small">{{ page.intro }}</h2>
+            {% endif %}
 
             {% include "patterns/components/author/author.html" with classes="blog__author author--blog" %}
         </header>
 
         {# Body Content #}
 
+        <div class="grid">
+            <div class="blog__content">
+                {% include_block page.body %}
+            </div>
+        </div>
     </article>
 
     {# Related articles #}

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
@@ -17,7 +17,6 @@
         </header>
 
         {# Body Content #}
-
         <div class="grid">
             <div class="blog__content">
                 {% include_block page.body %}

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
@@ -26,4 +26,5 @@
     </article>
 
     {# Related articles #}
+    {% include "patterns/components/related-content/related-content.html" with related_pages=page.related_pages.all %}
 {% endblock %}

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.yaml
@@ -10,27 +10,4 @@ tags:
         <img src="http://via.placeholder.com/90x90" width="90" height="90" alt="Some alt" class="author__image">
   include_block:
     page.body:
-      raw: |
-        <div class="rich-text">
-          <h2>A quick review of traditional vs. headless Wagtail</h2>
-          <p>In a traditional Wagtail website, almost all the technology you need to make the website work lives on a single server. In this one-server-to-rule-them-all structure, the database that houses your content, the stylesheets that make your website look pretty, the ecommerce code that lets users buy things or make donations, and the rest of the code that makes your website work is all in one place.</p>
-          <p>Headless Wagtail is set up like a jamstack. In a jamstack, the backend (things like the database and the editor where you make changes to your content) is separated from the frontend (things like styles that affect how your website looks and the forms users use to make purchases or update data) and other services (like authentication or ecommerce) that make your site run. Of the headless Wagtail setups that have been created so far, typically the CMS portion of Wagtail and the database are hosted on one server, the frontend portion of the website is hosted on another server, and there's an API that connects the two parts together that lets the frontend pull content and data from the backend.</p>
-          <h3>Who uses Headless Wagtail right now?</h3>
-          <p>Currently, there are governments, nonprofits, and publications using Headless Wagtail. Here are some examples you can explore:</p>
-          <ul>
-            <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
-            <li><a href="#">Gothamist</a></li>
-            <li><a href="#">M + Museum</a></li>
-            <li><a href="#">New York Public Radio</a></li>
-          </ul>
-          <p>There are also developers who've released experimental templates for Headless Wagtail and other projects. Here are two examples from GitHub:</p>
-          <ul>
-            <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
-            <li><a href="#">Gothamist</a></li>
-          </ul>
-          <h3>Upsides to Headless Wagtail</h3>
-          <h4>You can do more with your content</h4>
-          <p>With your content API, you can reuse the same content in multiple frontends. For example, the same blog content can feed into a website, a mobile app, and apps for devices like smartwatches.</p>
-          <h4>You don't have to do everything in Django and Wagtail</h4>
-          <p>Django is an incredibly powerful web framework, and there's very little you can't do in Django or Wagtail. But Headless Wagtail gives you more options to incorporate technologies that don't run on Python. For example, JavaScript-only frontends like Next.js or Gatsby, can be very cheap to host, and a headless structure can give you the option to experiment with those or other hosting arrangements.</p>
-        </div>
+      template_name: 'patterns/_pattern_library_only/blog_page_example.html'

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.yaml
@@ -8,3 +8,29 @@ tags:
     value.author_image fill-90x90 class="author__image":
       raw: |
         <img src="http://via.placeholder.com/90x90" width="90" height="90" alt="Some alt" class="author__image">
+  include_block:
+    page.body:
+      raw: |
+        <div class="rich-text">
+          <h2>A quick review of traditional vs. headless Wagtail</h2>
+          <p>In a traditional Wagtail website, almost all the technology you need to make the website work lives on a single server. In this one-server-to-rule-them-all structure, the database that houses your content, the stylesheets that make your website look pretty, the ecommerce code that lets users buy things or make donations, and the rest of the code that makes your website work is all in one place.</p>
+          <p>Headless Wagtail is set up like a jamstack. In a jamstack, the backend (things like the database and the editor where you make changes to your content) is separated from the frontend (things like styles that affect how your website looks and the forms users use to make purchases or update data) and other services (like authentication or ecommerce) that make your site run. Of the headless Wagtail setups that have been created so far, typically the CMS portion of Wagtail and the database are hosted on one server, the frontend portion of the website is hosted on another server, and there's an API that connects the two parts together that lets the frontend pull content and data from the backend.</p>
+          <h3>Who uses Headless Wagtail right now?</h3>
+          <p>Currently, there are governments, nonprofits, and publications using Headless Wagtail. Here are some examples you can explore:</p>
+          <ul>
+            <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
+            <li><a href="#">Gothamist</a></li>
+            <li><a href="#">M + Museum</a></li>
+            <li><a href="#">New York Public Radio</a></li>
+          </ul>
+          <p>There are also developers who've released experimental templates for Headless Wagtail and other projects. Here are two examples from GitHub:</p>
+          <ul>
+            <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
+            <li><a href="#">Gothamist</a></li>
+          </ul>
+          <h3>Upsides to Headless Wagtail</h3>
+          <h4>You can do more with your content</h4>
+          <p>With your content API, you can reuse the same content in multiple frontends. For example, the same blog content can feed into a website, a mobile app, and apps for devices like smartwatches.</p>
+          <h4>You don't have to do everything in Django and Wagtail</h4>
+          <p>Django is an incredibly powerful web framework, and there's very little you can't do in Django or Wagtail. But Headless Wagtail gives you more options to incorporate technologies that don't run on Python. For example, JavaScript-only frontends like Next.js or Gatsby, can be very cheap to host, and a headless structure can give you the option to experiment with those or other hosting arrangements.</p>
+        </div>

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.yaml
@@ -2,12 +2,31 @@ context:
   page:
     title: Do you need Headless Wagtail? A guide for decision makers
     intro: Here is a handy guide for decision makers who are considering Headless Wagtail.
+    related_pages:
+      all:
+        - heading: Preparations for Wagtail Space NL are in full swing
+          description: The preparations for Wagtail Space NL are going great. I want to inform you about the latest developments.
+          meta_icon: arrows
+          meta_text: Community
+          logo: fake
+          link_url: '#'
+          author: John Smith
+        - heading: How to try Wagtail CMS without coding
+          description: How to setup Wagtail and explore the content management system without any coding.
+          meta_icon: location-pin
+          meta_text: Resources
+          logo: fake
+          link_url: '#'
+          author: John Smith
 
 tags:
   image:
     value.author_image fill-90x90 class="author__image":
       raw: |
         <img src="http://via.placeholder.com/90x90" width="90" height="90" alt="Some alt" class="author__image">
+    value.logo fill-40x40 class="logo-card__image":
+      raw: |
+        <img src="https://placehold.co/40x40" alt="Some alt" class="logo-card__image">
   include_block:
     page.body:
       template_name: 'patterns/_pattern_library_only/blog_page_example.html'

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.yaml
@@ -1,0 +1,10 @@
+context:
+  page:
+    title: Do you need Headless Wagtail? A guide for decision makers
+    intro: Here is a handy guide for decision makers who are considering Headless Wagtail.
+
+tags:
+  image:
+    value.author_image fill-90x90 class="author__image":
+      raw: |
+        <img src="http://via.placeholder.com/90x90" width="90" height="90" alt="Some alt" class="author__image">

--- a/wagtailio/static/sass/base/_typography.scss
+++ b/wagtailio/static/sass/base/_typography.scss
@@ -122,6 +122,16 @@ h4,
     }
 }
 
+.article-heading {
+    font-size: 2.25rem;
+    line-height: 2.9rem;
+
+    @include media-query(large) {
+        font-size: 3.25rem;
+        line-height: 3.9rem;
+    }
+}
+
 small {
     font-size: 1rem;
     line-height: 1.5rem;

--- a/wagtailio/static/sass/components/_author.scss
+++ b/wagtailio/static/sass/components/_author.scss
@@ -1,4 +1,5 @@
 .author {
+    $root: &;
     display: flex;
     align-items: center;
 
@@ -10,5 +11,11 @@
 
     &__name {
         font-weight: $weight--bold;
+    }
+
+    &--blog {
+        #{$root}__image {
+            border-radius: 50%;
+        }
     }
 }

--- a/wagtailio/static/sass/components/_blog.scss
+++ b/wagtailio/static/sass/components/_blog.scss
@@ -1,0 +1,35 @@
+.blog {
+    &__meta,
+    &__intro,
+    &__author,
+    &__heading {
+        grid-column: 2 / span 2;
+
+        @include media-query(medium) {
+            grid-column: 2 / span 3;
+        }
+
+        @include media-query(large) {
+            grid-column: 2 / span 4;
+        }
+    }
+
+    &__intro {
+        font-weight: $weight--regular;
+
+        @include media-query(large) {
+            grid-column: 2 / span 3;
+        }
+    }
+
+    &__meta {
+        margin-bottom: 20px;
+    }
+
+    &__intro,
+    &__heading {
+        @include media-query(large) {
+            margin-bottom: 30px;
+        }
+    }
+}

--- a/wagtailio/static/sass/components/_blog.scss
+++ b/wagtailio/static/sass/components/_blog.scss
@@ -32,4 +32,28 @@
             margin-bottom: 30px;
         }
     }
+
+    &__content {
+        grid-column: 2 / span 2;
+
+        @include media-query(large) {
+            grid-column: 2 / span 3;
+        }
+
+        @include media-query(large) {
+            grid-column: 3 / span 3;
+        }
+    }
+
+    &__header {
+        padding-bottom: 50px;
+
+        @include media-query(medium) {
+            padding-bottom: 100px;
+        }
+
+        @include media-query(large) {
+            padding-bottom: 200px;
+        }
+    }
 }

--- a/wagtailio/static/sass/components/_blog.scss
+++ b/wagtailio/static/sass/components/_blog.scss
@@ -35,9 +35,11 @@
 
     &__content {
         grid-column: 2 / span 2;
+        margin-bottom: 50px;
 
         @include media-query(large) {
             grid-column: 2 / span 3;
+            margin-bottom: 100px;
         }
 
         @include media-query(large) {

--- a/wagtailio/static/sass/components/_logo-card.scss
+++ b/wagtailio/static/sass/components/_logo-card.scss
@@ -34,7 +34,16 @@
     }
 
     &__image {
-        margin-top: auto;
+        flex-shrink: 0;
+    }
+
+    &__author-wrap {
+        display: flex;
+        align-items: center;
+    }
+
+    &__author {
+        margin-left: 10px;
     }
 
     &:is(a) {
@@ -60,6 +69,12 @@
             &::after {
                 transform: rotate(-5deg) translate3d(-30px, 45px, 0);
             }
+        }
+    }
+
+    &--article {
+        #{$root}__image {
+            border-radius: 50%;
         }
     }
 }

--- a/wagtailio/static/sass/components/_meta.scss
+++ b/wagtailio/static/sass/components/_meta.scss
@@ -21,4 +21,11 @@
             transform: rotate(-10deg);
         }
     }
+
+    // Overrides
+    .logo-card--article & {
+        &__text {
+            font-weight: $weight--bold;
+        }
+    }
 }

--- a/wagtailio/static/sass/components/_related-content.scss
+++ b/wagtailio/static/sass/components/_related-content.scss
@@ -1,0 +1,43 @@
+.related-content {
+    margin-bottom: 50px;
+
+    @include media-query(large) {
+        margin-bottom: 100px;
+    }
+
+    &__heading {
+        font-weight: $weight--regular;
+        grid-column: 2 / span 2;
+        margin-bottom: 30px;
+
+        @include media-query(large) {
+            margin-bottom: 50px;
+        }
+    }
+
+    &__items {
+        display: flex;
+        flex-direction: column;
+        grid-column: 2 / span 2;
+
+        @include media-query(medium) {
+            grid-column: 2 / span 3;
+        }
+
+        @include media-query(large) {
+            flex-direction: row;
+            gap: 170px;
+            grid-column: 2 / span 5;
+
+        }
+    }
+
+    &__item {
+        max-width: 490px;
+        margin-bottom: 30px;
+
+        @include media-query(large) {
+            margin-bottom: 0;
+        }
+    }
+}

--- a/wagtailio/static/sass/components/_rich-text.scss
+++ b/wagtailio/static/sass/components/_rich-text.scss
@@ -1,9 +1,10 @@
 .rich-text {
     a {
         color: $color--teal;
+        transition: color 0.3s;
 
         &:hover {
-            // Design TBC
+            color: $color--indigo;
         }
     }
 
@@ -11,9 +12,13 @@
         font-weight: $weight--bold;
     }
 
-    ul, ol {
-        li {
-            margin-bottom: 10px;
+    ul,
+    ol {
+        list-style: inside;
+        margin-bottom: 20px;
+
+        @include media-query(medium) {
+            margin-bottom: 40px;
         }
     }
 

--- a/wagtailio/static/sass/main.scss
+++ b/wagtailio/static/sass/main.scss
@@ -32,6 +32,7 @@
 @import 'components/meta';
 @import 'components/modal';
 @import 'components/quotes';
+@import 'components/related-content';
 @import 'components/rich-text';
 @import 'components/responsive-object';
 @import 'components/search-result';

--- a/wagtailio/static/sass/main.scss
+++ b/wagtailio/static/sass/main.scss
@@ -13,6 +13,7 @@
 
 // Components
 @import 'components/author';
+@import 'components/blog';
 @import 'components/buttons';
 @import 'components/cta';
 @import 'components/form.scss';


### PR DESCRIPTION
Adds the blog page, viewable [in the pattern library here](http://localhost:8000/pattern-library/render-pattern/patterns/pages/blog/blog_page.html).

Also:
- Adds a `rich-text-example.html` template
- Adds rich text link hover styles (these had been added previously so not sure where they went)
- Adds `related-content.html` which makes use of `logo_card_block.html`