### PR TITLE
Blog page fixes

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/_pattern_library_only/rich_text_example.html
+++ b/wagtailio/project_styleguide/templates/patterns/_pattern_library_only/rich_text_example.html
@@ -1,23 +1,25 @@
-<div class="rich-text">
-    <h2>A quick review of traditional vs. headless Wagtail</h2>
-    <p>In a traditional Wagtail website, almost all the technology you need to make the website work lives on a single server. In this one-server-to-rule-them-all structure, the database that houses your content, the stylesheets that make your website look pretty, the ecommerce code that lets users buy things or make donations, and the rest of the code that makes your website work is all in one place.</p>
-    <p>Headless Wagtail is set up like a jamstack. In a jamstack, the backend (things like the database and the editor where you make changes to your content) is separated from the frontend (things like styles that affect how your website looks and the forms users use to make purchases or update data) and other services (like authentication or ecommerce) that make your site run. Of the headless Wagtail setups that have been created so far, typically the CMS portion of Wagtail and the database are hosted on one server, the frontend portion of the website is hosted on another server, and there's an API that connects the two parts together that lets the frontend pull content and data from the backend.</p>
-    <h3>Who uses Headless Wagtail right now?</h3>
-    <p>Currently, there are governments, nonprofits, and publications using Headless Wagtail. Here are some examples you can explore:</p>
-    <ul>
-        <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
-        <li><a href="#">Gothamist</a></li>
-        <li><a href="#">M + Museum</a></li>
-        <li><a href="#">New York Public Radio</a></li>
-    </ul>
-    <p>There are also developers who've released experimental templates for Headless Wagtail and other projects. Here are two examples from GitHub:</p>
-    <ul>
-        <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
-        <li><a href="#">Gothamist</a></li>
-    </ul>
-    <h3>Upsides to Headless Wagtail</h3>
-    <h4>You can do more with your content</h4>
-    <p>With your content API, you can reuse the same content in multiple frontends. For example, the same blog content can feed into a website, a mobile app, and apps for devices like smartwatches.</p>
-    <h4>You don't have to do everything in Django and Wagtail</h4>
-    <p>Django is an incredibly powerful web framework, and there's very little you can't do in Django or Wagtail. But Headless Wagtail gives you more options to incorporate technologies that don't run on Python. For example, JavaScript-only frontends like Next.js or Gatsby, can be very cheap to host, and a headless structure can give you the option to experiment with those or other hosting arrangements.</p>
+<div class="grid">
+    <div class="rich-text rich-text--sf">
+        <h2>A quick review of traditional vs. headless Wagtail</h2>
+        <p>In a traditional Wagtail website, almost all the technology you need to make the website work lives on a single server. In this one-server-to-rule-them-all structure, the database that houses your content, the stylesheets that make your website look pretty, the ecommerce code that lets users buy things or make donations, and the rest of the code that makes your website work is all in one place.</p>
+        <p>Headless Wagtail is set up like a jamstack. In a jamstack, the backend (things like the database and the editor where you make changes to your content) is separated from the frontend (things like styles that affect how your website looks and the forms users use to make purchases or update data) and other services (like authentication or ecommerce) that make your site run. Of the headless Wagtail setups that have been created so far, typically the CMS portion of Wagtail and the database are hosted on one server, the frontend portion of the website is hosted on another server, and there's an API that connects the two parts together that lets the frontend pull content and data from the backend.</p>
+        <h3>Who uses Headless Wagtail right now?</h3>
+        <p>Currently, there are governments, nonprofits, and publications using Headless Wagtail. Here are some examples you can explore:</p>
+        <ul>
+            <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
+            <li><a href="#">Gothamist</a></li>
+            <li><a href="#">M + Museum</a></li>
+            <li><a href="#">New York Public Radio</a></li>
+        </ul>
+        <p>There are also developers who've released experimental templates for Headless Wagtail and other projects. Here are two examples from GitHub:</p>
+        <ul>
+            <li><a href="#">Jet Propulsion Laboratory — NASA</a></li>
+            <li><a href="#">Gothamist</a></li>
+        </ul>
+        <h3>Upsides to Headless Wagtail</h3>
+        <h4>You can do more with your content</h4>
+        <p>With your content API, you can reuse the same content in multiple frontends. For example, the same blog content can feed into a website, a mobile app, and apps for devices like smartwatches.</p>
+        <h4>You don't have to do everything in Django and Wagtail</h4>
+        <p>Django is an incredibly powerful web framework, and there's very little you can't do in Django or Wagtail. But Headless Wagtail gives you more options to incorporate technologies that don't run on Python. For example, JavaScript-only frontends like Next.js or Gatsby, can be very cheap to host, and a headless structure can give you the option to experiment with those or other hosting arrangements.</p>
+    </div>
 </div>

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.html
@@ -17,11 +17,7 @@
         </header>
 
         {# Body Content #}
-        <div class="grid">
-            <div class="blog__content">
-                {% include_block page.body %}
-            </div>
-        </div>
+        {% include_block page.body %}
     </article>
 
     {# Related articles #}

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_page.yaml
@@ -21,9 +21,9 @@ context:
 
 tags:
   image:
-    value.author_image fill-90x90 class="author__image":
+    author.image fill-90x90 class="author__image":
       raw: |
-        <img src="http://via.placeholder.com/90x90" width="90" height="90" alt="Some alt" class="author__image">
+        <img src="https://placehold.co/90x90" width="90" height="90" alt="Some alt" class="author__image">
     value.logo fill-40x40 class="logo-card__image":
       raw: |
         <img src="https://placehold.co/40x40" alt="Some alt" class="logo-card__image">

--- a/wagtailio/static/sass/components/_blog.scss
+++ b/wagtailio/static/sass/components/_blog.scss
@@ -33,20 +33,6 @@
         }
     }
 
-    &__content {
-        grid-column: 2 / span 2;
-        margin-bottom: 50px;
-
-        @include media-query(large) {
-            grid-column: 2 / span 3;
-            margin-bottom: 100px;
-        }
-
-        @include media-query(large) {
-            grid-column: 3 / span 3;
-        }
-    }
-
     &__header {
         padding-bottom: 50px;
 


### PR DESCRIPTION
Spotted a couple of bugs on the blog page:
- Remove wrapping blog content class as the SF's used on the page have their own grid class
- Fixes author image on blog page
- Adds grid class to rich text example template