### PR TITLE
Fix broken rendering of 'get started' block on Content page template

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/content_story_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/content_story_block.html
@@ -1,5 +1,9 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 {% for block in value %}
-    {% include_block block %}
+    {% if block.block_type == 'get_started_block' %}
+        {{ block.value.body }}
+    {% else %}
+        {% include_block block %}
+    {% endif %}
 {% endfor %}


### PR DESCRIPTION
This is a fix to ensure that the _get started_ block in the **ContentPage**'s body StreamField actually renders when it is included. 

Prior to this, the block did not render