### PR TITLE
Fix rendering of related pages on blog page

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/meta/meta.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/meta/meta.html
@@ -10,4 +10,10 @@
             <p class="meta__date mini-meta mini-meta">{{ value.publication_date|date:"j M Y" }}</p>
         {% endif %}
     </div>
+{% elif value.publication_date %}
+    <div class="meta{% if classes %} {{ classes }}{% endif %}">
+        {% include "patterns/components/icon/icon.html" with icon="calendar" classes="meta__icon" %}
+
+        <p class="meta__date mini-meta mini-meta">{{ value.publication_date|date:"j M Y" }}</p>
+    </div>
 {% endif %}

--- a/wagtailio/project_styleguide/templates/patterns/components/related-content/related-content.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/related-content/related-content.html
@@ -5,7 +5,7 @@
         <div class="related-content__items">
             {% for related in related_pages %}
                 <article class="related-content__item">
-                    {% include "patterns/components/streamfields/cards/logo_card_block.html" with value=related classes="logo-card--article" %}
+                    {% include "patterns/components/streamfields/cards/related_page_card_block.html" with value=related.page classes="logo-card--article" %}
                 </article>
             {% endfor %}
         </div>

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_card_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_card_block.html
@@ -1,3 +1,14 @@
+{% comment %}
+This template is very similar to patterns/components/streamfields/cards/related_page_card_block.html
+The reason for the separation is because of differing context variable names, for example
+    | logo_card_block.html            | related_page_card_block.html      |
+    | ------------------------------- | --------------------------------- |
+    | value.link_url                  |  value.url                        |
+    | value.heading                   |  value.title                      |
+    | value.description (rich text)   |  value.introduction (plain text)  |
+    | value.logo                      |  -                                |
+{% endcomment %}
+
 {% load wagtailcore_tags wagtailimages_tags %}
 {% if value.link_url %}
     <a href="{{ value.link_url }}" class="logo-card {% if classes %}{{ classes }}{% endif %}">

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.html
@@ -1,3 +1,14 @@
+{% comment %}
+This template is based on patterns/components/streamfields/cards/logo_card_block.html
+The reason for the separation is because of differing context variable names, for example
+    | logo_card_block.html            | related_page_card_block.html      |
+    | ------------------------------- | --------------------------------- |
+    | value.link_url                  |  value.url                        |
+    | value.heading                   |  value.title                      |
+    | value.description (rich text)   |  value.introduction (plain text)  |
+    | value.logo                      |  -                                |
+{% endcomment %}
+
 {% load wagtailcore_tags wagtailimages_tags %}
 <a href="{{ value.url }}" class="logo-card {% if classes %}{{ classes }}{% endif %}">
     {% include "patterns/components/meta/meta.html" with classes="logo-card__meta" %}

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.html
@@ -1,0 +1,16 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+<a href="{{ value.url }}" class="logo-card {% if classes %}{{ classes }}{% endif %}">
+    {% include "patterns/components/meta/meta.html" with classes="logo-card__meta" %}
+
+    <h4 class="logo-card__heading teaser-heading">{{ value.title }}</h4>
+
+    <div class="logo-card__description">{{ value.introduction }}</div>
+
+    {% if value.author %}
+        <div class="logo-card__author-wrap">
+            {% if value.author.image %}{% image value.author.image fill-40x40 class="logo-card__image" %}{% endif %}
+            <p class="logo-card__author mini-meta">{{ value.author.name }}</p>
+        </div>
+    {% endif %}
+
+</a>

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.yaml
@@ -1,0 +1,18 @@
+context:
+  value:
+    title: This is a lovely blog post
+    introduction: And now, ladies and gentlemen, some lorem ipsum text
+    meta_icon: rocket
+    meta_text: Adventures in Wagtail
+    publication_date: !!timestamp '2022-08-19'
+    author:
+      name: Jane Doe
+      job_title: Chef
+      image: fake
+    url: 'https://www.example.co.uk'
+
+tags:
+  image:
+    value.author.image fill-40x40 class="logo-card__image":
+      raw: |
+        <img src="https://placehold.co/40x40" alt="Some alt" class="logo-card__image">


### PR DESCRIPTION
This MR picks up from #222, and provides a fix to ensure that related pages are displayed on a blog page.

Details of the fix

1. Instead of using [logo_card_block.html](https://github.com/wagtail/wagtail.org/blob/ce622774084d59d669ed8a49adee0839312d7488/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_card_block.html) as the template, create a new template [related_page_card_block.html](https://github.com/wagtail/wagtail.org/blob/16f8719fbaaf6b974867e7d4aa2f3f0b9133ea9d/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.html), which is essentially a copy of the former, but with updated field names to match the **BlogPage** model.
2. Fix `value` in [patterns/components/related-content/related-content.html](https://github.com/wagtail/wagtail.org/blob/ce622774084d59d669ed8a49adee0839312d7488/wagtailio/project_styleguide/templates/patterns/components/related-content/related-content.html#L8) and update template path as in (1) above:

```diff
- {% include "patterns/components/streamfields/cards/logo_card_block.html" with value=related classes="logo-card--article" %}
+ {% include "patterns/components/streamfields/cards/related_page_card_block.html" with value=related.page classes="logo-card--article" %}
```

<details><summary>

### Screenshots

</summary>

With category

![Screenshot 2022-08-19 at 14-17-11 Getting started in Wagtail a newcomer's perspective Wagtail CMS](https://user-images.githubusercontent.com/7713776/185622837-c50ddd35-241f-44f3-9c9c-b3fd89d3793f.png)

No category

![Screenshot from 2022-08-19 14-10-35](https://user-images.githubusercontent.com/7713776/185622876-905dd7a2-8639-4693-bf77-7d9c1fd98a2b.png)

</details>