### PR TITLE
Comparison table column fix

### DIFF
--- a/wagtailio/static/sass/components/_comparison-table.scss
+++ b/wagtailio/static/sass/components/_comparison-table.scss
@@ -7,7 +7,11 @@
 
     td:first-child {
         font-weight: $weight--bold;
-        min-width: fit-content;
+        width: 150px;
+
+        @include media-query(large) {
+            width: 250px
+        }
     }
 
     tbody {

--- a/wagtailio/static/sass/components/_comparison-table.scss
+++ b/wagtailio/static/sass/components/_comparison-table.scss
@@ -7,6 +7,7 @@
 
     td:first-child {
         font-weight: $weight--bold;
+        min-width: fit-content;
     }
 
     tbody {


### PR DESCRIPTION
This tweak forces the table "categories" to maintain their sizing regardless of large images being added.