### PR TITLE
Add config for security headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ scout-apm==2.23.5
 mammoth==1.4.18  # used for curstom wagtail content import parser
 
 django-basic-auth-ip-whitelist==0.3.4
+django-csp==3.7
 django-referrer-policy==1.0
 
 # wagtail packages

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ mammoth==1.4.18  # used for curstom wagtail content import parser
 
 django-basic-auth-ip-whitelist==0.3.4
 django-csp==3.7
+django-permissions-policy==4.13.0
 django-referrer-policy==1.0
 
 # wagtail packages

--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -329,11 +329,26 @@ SECURE_SSL_REDIRECT = True
 # https://docs.djangoproject.com/en/stable/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+# This is a setting activating the HSTS header. This will enforce the visitors to use
+# HTTPS for an amount of time specified in the header. Since we are expecting our apps
+# to run via TLS by default, this header is activated by default.
+# The header can be deactivated by setting this setting to 0, as it is done in the
+# dev and testing settings.
+# https://docs.djangoproject.com/en/stable/ref/settings/#secure-hsts-seconds
+DEFAULT_HSTS_SECONDS = 30 * 24 * 60 * 60  # 30 days
+SECURE_HSTS_SECONDS = DEFAULT_HSTS_SECONDS
 if "SECURE_HSTS_SECONDS" in env:
     try:
         SECURE_HSTS_SECONDS = int(env["SECURE_HSTS_SECONDS"])
     except ValueError:
         pass
+
+# Do not use the `includeSubDomains` directive for HSTS. This needs to be prevented
+# because the apps are running on client domains (or our own for staging), that are
+# being used for other applications as well. We should therefore not impose any
+# restrictions on these unrelated applications.
+# https://docs.djangoproject.com/en/3.2/ref/settings/#secure-hsts-include-subdomains
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
 
 # https://docs.djangoproject.com/en/stable/ref/settings/#secure-browser-xss-filter
 SECURE_BROWSER_XSS_FILTER = True

--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -357,6 +357,31 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
 
+# Content Security policy settings
+# http://django-csp.readthedocs.io/en/latest/configuration.html
+if "CSP_DEFAULT_SRC" in env:
+    MIDDLEWARE.append("csp.middleware.CSPMiddleware")
+
+    # The “special” source values of 'self', 'unsafe-inline', 'unsafe-eval', and 'none' must be quoted!
+    # e.g.: CSP_DEFAULT_SRC = "'self'" Without quotes they will not work as intended.
+
+    CSP_DEFAULT_SRC = env["CSP_DEFAULT_SRC"].split(",")
+    if "CSP_SCRIPT_SRC" in env:
+        CSP_SCRIPT_SRC = env["CSP_SCRIPT_SRC"].split(",")
+    if "CSP_STYLE_SRC" in env:
+        CSP_STYLE_SRC = env["CSP_STYLE_SRC"].split(",")
+    if "CSP_IMG_SRC" in env:
+        CSP_IMG_SRC = env["CSP_IMG_SRC"].split(",")
+    if "CSP_CONNECT_SRC" in env:
+        CSP_CONNECT_SRC = env["CSP_CONNECT_SRC"].split(",")
+    if "CSP_FONT_SRC" in env:
+        CSP_FONT_SRC = env["CSP_FONT_SRC"].split(",")
+    if "CSP_BASE_URI" in env:
+        CSP_BASE_URI = env["CSP_BASE_URI"].split(",")
+    if "CSP_OBJECT_SRC" in env:
+        CSP_OBJECT_SRC = env["CSP_OBJECT_SRC"].split(",")
+
+
 # Referrer-policy header settings
 # https://django-referrer-policy.readthedocs.io/en/1.0/
 

--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -396,7 +396,6 @@ PERMISSIONS_POLICY = {
     "display-capture": [],
     "document-domain": [],
     "encrypted-media": [],
-    "fullscreen": [],
     "geolocation": [],
     "gyroscope": [],
     "interest-cohort": [],

--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -316,12 +316,17 @@ if "SERVER_EMAIL" in env:
 
 WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = env.get("MODERATION_NOTIFY_SUPERUSERS", False)
 
+
 # Security configuration
 # https://docs.djangoproject.com/en/stable/ref/middleware/#module-django.middleware.security
 
-if env.get("SECURE_SSL_REDIRECT", "true").strip().lower() == "true":
-    SECURE_SSL_REDIRECT = True
+# Force HTTPS redirect (enabled by default!)
+# https://docs.djangoproject.com/en/stable/ref/settings/#secure-ssl-redirect
+SECURE_SSL_REDIRECT = True
 
+# This will allow the cache to swallow the fact that the website is behind TLS
+# and inform the Django using "X-Forwarded-Proto" HTTP header.
+# https://docs.djangoproject.com/en/stable/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 if "SECURE_HSTS_SECONDS" in env:
@@ -330,11 +335,11 @@ if "SECURE_HSTS_SECONDS" in env:
     except ValueError:
         pass
 
-if env.get("SECURE_BROWSER_XSS_FILTER", "true").lower().strip() == "true":
-    SECURE_BROWSER_XSS_FILTER = True
+# https://docs.djangoproject.com/en/stable/ref/settings/#secure-browser-xss-filter
+SECURE_BROWSER_XSS_FILTER = True
 
-if env.get("SECURE_CONTENT_TYPE_NOSNIFF", "true").lower().strip() == "true":
-    SECURE_CONTENT_TYPE_NOSNIFF = True
+# https://docs.djangoproject.com/en/stable/ref/settings/#secure-content-type-nosniff
+SECURE_CONTENT_TYPE_NOSNIFF = True
 
 
 # Referrer-policy header settings

--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -97,6 +97,7 @@ INSTALLED_APPS = (
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "django_permissions_policy.PermissionsPolicyMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -381,6 +382,31 @@ if "CSP_DEFAULT_SRC" in env:
     if "CSP_OBJECT_SRC" in env:
         CSP_OBJECT_SRC = env["CSP_OBJECT_SRC"].split(",")
 
+
+# Permissions policy settings
+# Uses django-permissions-policy to return the header.
+# https://github.com/adamchainz/django-permissions-policy
+# The list of Chrome-supported features are in:
+# https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md
+PERMISSIONS_POLICY = {
+    "accelerometer": [],
+    "ambient-light-sensor": [],
+    "autoplay": [],
+    "camera": [],
+    "display-capture": [],
+    "document-domain": [],
+    "encrypted-media": [],
+    "fullscreen": [],
+    "geolocation": [],
+    "gyroscope": [],
+    "interest-cohort": [],
+    "magnetometer": [],
+    "microphone": [],
+    "midi": [],
+    "payment": [],
+    "picture-in-picture": [],
+    "usb": [],
+}
 
 # Referrer-policy header settings
 # https://django-referrer-policy.readthedocs.io/en/1.0/


### PR DESCRIPTION
Related to #5 

### When applied, this MR will...

set up the `Strict-Transport-Security` (HSTS), `Content-Security-Policy` (CSP), and `Permissions-Policy` headers.

### Please provide detail on the technical changes, if relevant

- tweak some existing config:
    - Force `SECURE_SSL_REDIRECT` as true always
    - Set up a default value of 30 days for `SECURE_HSTS_SECONDS`
- use `django-csp` and environment variables for CSP headers, and
- use `django-permissions-policy` for Permissions Policy headers.
    - I've set most of the features as disabled because it doesn't look like we need them for wagtail.org (except `fullscreen` which I left out so that we can still use full screen with youtube videos)