### PR TITLE
Text & Media CTA

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/text_and_media_block/text_and_media_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/text_and_media_block/text_and_media_block.html
@@ -12,7 +12,7 @@
         <h2>{{ value.heading }}</h2>
         <p>{{ value.description }}</p>
         {% if value.cta.text %}
-            {% include "patterns/components/streamfields/cta/cta_block.html" with value=value.cta classes="text-media__button" %}
+            {% include "patterns/components/buttons/button.html" with url=value.cta.url title=value.cta.text arrow=True classes="text-media__button" %}
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
`cta_block.html` contains a `grid` class for when it's used as a SF but in this instance it's causing alignment issues when used a child of a SF. Using `button.html` resolves this.

Before: 

![Screenshot 2022-08-25 at 10 31 30](https://user-images.githubusercontent.com/31627284/186629949-d6fcd65c-a5c5-478f-b610-dec695bb7fcd.png)

After:

![Screenshot 2022-08-25 at 10 31 19](https://user-images.githubusercontent.com/31627284/186629983-1605bc8d-41ec-4780-8303-e38a2f38af08.png)

