### PR TITLE
Add property to hide hero

### DIFF
--- a/wagtailio/core/models/mixins.py
+++ b/wagtailio/core/models/mixins.py
@@ -31,5 +31,9 @@ class HeroMixin(models.Model):
         )
     ]
 
+    @property
+    def has_hero(self):
+        return any([self.heading, self.sub_heading, self.intro, self.icon, self.cta])
+
     class Meta:
         abstract = True

--- a/wagtailio/project_styleguide/templates/patterns/pages/content_page/content_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/content_page/content_page.html
@@ -2,7 +2,9 @@
 {% load wagtailcore_tags wagtailimages_tags static %}
 
 {% block content %}
-    {% include "patterns/components/hero/hero.html" with value=page %}
+    {% if page.has_hero %}
+        {% include "patterns/components/hero/hero.html" with value=page %}
+    {% endif %}
 
     {% include_block page.body %}
 {% endblock %}

--- a/wagtailio/project_styleguide/templates/patterns/pages/content_page/content_page.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/pages/content_page/content_page.yaml
@@ -1,5 +1,6 @@
 context:
   page:
+    has_hero: True
     title: Content page
     heading: Wagtail Hero heading
     sub_heading: This is a sub-heading


### PR DESCRIPTION
This is a simple approach to not display the hero on content_page templates that do not supply hero variables.