### PR TITLE
add fixed position to header when mobile menu is open

### DIFF
--- a/wagtailio/static/css/components/header.scss
+++ b/wagtailio/static/css/components/header.scss
@@ -25,7 +25,7 @@
 }
 
 .mobile_nav-open {
-  & .header {
+  .header {
     position: fixed;
   }
 }

--- a/wagtailio/static/css/components/header.scss
+++ b/wagtailio/static/css/components/header.scss
@@ -22,6 +22,10 @@
     max-width: $max-width;
     margin: 0 auto;
   }
+
+  &.fixed {
+    position: fixed;
+  }
 }
 
 .site-header {

--- a/wagtailio/static/css/components/header.scss
+++ b/wagtailio/static/css/components/header.scss
@@ -22,8 +22,10 @@
     max-width: $max-width;
     margin: 0 auto;
   }
+}
 
-  &.fixed {
+.mobile_nav-open {
+  & .header {
     position: fixed;
   }
 }

--- a/wagtailio/static/js/main.js
+++ b/wagtailio/static/js/main.js
@@ -77,6 +77,7 @@ $(function() {
   $(".menu-toggle").on("click", function(e) {
     e.preventDefault();
     $("body").toggleClass("mobile_nav-open");
+    $("header").toggleClass("fixed");
   });
 
   // Blog index for mobile button

--- a/wagtailio/static/js/main.js
+++ b/wagtailio/static/js/main.js
@@ -77,7 +77,6 @@ $(function() {
   $(".menu-toggle").on("click", function(e) {
     e.preventDefault();
     $("body").toggleClass("mobile_nav-open");
-    $("header").toggleClass("fixed");
   });
 
   // Blog index for mobile button


### PR DESCRIPTION
Fixes the second issue of #260 and makes the header fixed at the top of the screen when the mobile menu is open.