### PR TITLE
Updated embedded Mailchimp form to reflect new list ID

### DIFF
--- a/wagtailio/newsletter/templates/newsletter/newsletter_index_page.html
+++ b/wagtailio/newsletter/templates/newsletter/newsletter_index_page.html
@@ -16,34 +16,41 @@
         </header>
 
         <div class="container">
-            <!-- Begin Mailchimp Signup Form -->
-            <link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
-            <style type="text/css">
-                #mc_embed_signup{clear:left; font:14px Helvetica,Arial,sans-serif; }
-                /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
-                We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
-            </style>
-            <div id="mc_embed_signup">
-            <form action="https://torchbox.us1.list-manage.com/subscribe/post?u=fa038e191e9c77563d1c3bfa4&amp;id=ac422ce60a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+        <!-- Begin Mailchimp Signup Form -->
+        <link href="//cdn-images.mailchimp.com/embedcode/classic-071822.css" rel="stylesheet" type="text/css">
+        <style type="text/css">
+            #mc_embed_signup {clear:left; font:14px Helvetica,Arial,sans-serif;}
+
+            /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+            We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+        </style>
+        <div id="mc_embed_signup">
+            <form
+                action="https://torchbox.us1.list-manage.com/subscribe/post?u=fa038e191e9c77563d1c3bfa4&amp;id=e609703ef2&amp;f_id=000270e2f0"
+                method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self">
                 <div id="mc_embed_signup_scroll">
-                <h2>Subscribe to This Week in Wagtail</h2>
-            <div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
-            <div class="mc-field-group">
-                <label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
-            </label>
-                <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
-            </div>
-                <div id="mce-responses" class="clear">
-                    <div class="response" id="mce-error-response" style="display:none"></div>
-                    <div class="response" id="mce-success-response" style="display:none"></div>
-                </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-                <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_fa038e191e9c77563d1c3bfa4_ac422ce60a" tabindex="-1" value=""></div>
-                <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+                    <h2>Subscribe to This Week in Wagtail</h2>
+                    <div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+                    <div class="mc-field-group">
+                        <label for="mce-EMAIL">Email Address <span class="asterisk">*</span>
+                        </label>
+                        <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" required>
+                        <span id="mce-EMAIL-HELPERTEXT" class="helper_text"></span>
+                    </div>
+                    <div id="mce-responses" class="clear">
+                        <div class="response" id="mce-error-response" style="display:none"></div>
+                        <div class="response" id="mce-success-response" style="display:none"></div>
+                    </div>
+                    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text"
+                            name="b_fa038e191e9c77563d1c3bfa4_e609703ef2" tabindex="-1" value=""></div>
+                    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe"
+                            class="button"></div>
                 </div>
             </form>
-            </div>
+        </div>
 
-            <!--End mc_embed_signup-->
+        <!--End mc_embed_signup-->
 
             {% if newsletters %}
                 <h3>Previous issues</h3>

--- a/wagtailio/newsletter/templates/newsletter/newsletter_index_page.html
+++ b/wagtailio/newsletter/templates/newsletter/newsletter_index_page.html
@@ -16,41 +16,39 @@
         </header>
 
         <div class="container">
-        <!-- Begin Mailchimp Signup Form -->
-        <link href="//cdn-images.mailchimp.com/embedcode/classic-071822.css" rel="stylesheet" type="text/css">
-        <style type="text/css">
-            #mc_embed_signup {clear:left; font:14px Helvetica,Arial,sans-serif;}
-
-            /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
-            We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
-        </style>
-        <div id="mc_embed_signup">
-            <form
-                action="https://torchbox.us1.list-manage.com/subscribe/post?u=fa038e191e9c77563d1c3bfa4&amp;id=e609703ef2&amp;f_id=000270e2f0"
-                method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self">
+            <!-- Begin Mailchimp Signup Form -->
+            <link href="//cdn-images.mailchimp.com/embedcode/classic-071822.css" rel="stylesheet" type="text/css">
+            <style type="text/css">
+                #mc_embed_signup {clear:left; font:14px Helvetica,Arial,sans-serif; }
+                /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+                We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+            </style>
+            <div id="mc_embed_signup">
+            <form action="https://torchbox.us1.list-manage.com/subscribe/post?u=fa038e191e9c77563d1c3bfa4&amp;id=e609703ef2&amp;f_id=000270e2f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self">
                 <div id="mc_embed_signup_scroll">
-                    <h2>Subscribe to This Week in Wagtail</h2>
-                    <div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
-                    <div class="mc-field-group">
-                        <label for="mce-EMAIL">Email Address <span class="asterisk">*</span>
-                        </label>
-                        <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" required>
-                        <span id="mce-EMAIL-HELPERTEXT" class="helper_text"></span>
-                    </div>
-                    <div id="mce-responses" class="clear">
-                        <div class="response" id="mce-error-response" style="display:none"></div>
-                        <div class="response" id="mce-success-response" style="display:none"></div>
-                    </div>
-                    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-                    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text"
-                            name="b_fa038e191e9c77563d1c3bfa4_e609703ef2" tabindex="-1" value=""></div>
-                    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe"
-                            class="button"></div>
+                <h2>Subscribe to This Week in Wagtail</h2>
+                <div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+                <div class="mc-field-group">
+                    <label for="mce-EMAIL">Email Address <span class="asterisk">*</span></label>
+                    <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" required>
+                    <span id="mce-EMAIL-HELPERTEXT" class="helper_text"></span>
+                </div>
+                <div id="mce-responses" class="clear">
+                    <div class="response" id="mce-error-response" style="display:none"></div>
+                    <div class="response" id="mce-success-response" style="display:none"></div>
+                </div> 
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px;" aria-hidden="true">
+                    <input type="text" name="b_fa038e191e9c77563d1c3bfa4_e609703ef2" tabindex="-1" value="">
+                </div>
+                <div class="clear">
+                    <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
+                </div>
                 </div>
             </form>
-        </div>
+            </div>
 
-        <!--End mc_embed_signup-->
+            <!--End mc_embed_signup-->
 
             {% if newsletters %}
                 <h3>Previous issues</h3>


### PR DESCRIPTION
An attempt to consolidate Mailchimp lists for our Wagtail Newsletters went awry and I needed to recreate the list. I've updated the embedded form in the newsletter index page template to include the new audience ids.

I realized a bit belatedly that I could have just switched out the audience ids rather that replacing the whole form. So the code formatting is a bit different now. I'll correct anything that fails the style check, but if there is anything else that needs to be fixed, please let me know.