### PR TITLE
Docker compose update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,13 @@ services:
     environment:
       SECRET_KEY: fake
       DJANGO_SETTINGS_MODULE: wagtailio.settings.dev
-      DATABASE_URL: postgres://wagtailio:wagtailio@db:5432/wagtailio
+      DATABASE_URL: postgres://wagtailorg:wagtailorg@db:5432/wagtailorg
 
       # The env vars get picked up by postgresql client tools (psql, pg_dump, etc)
       PGHOST: db
-      PGUSER: wagtailio
-      PGPASSWORD: wagtailio
-      PGDATABASE: wagtailio
+      PGUSER: wagtailorg
+      PGPASSWORD: wagtailorg
+      PGDATABASE: wagtailorg
     ports:
       - 8000:8000
     volumes:
@@ -31,17 +31,17 @@ services:
     expose:
       - 5432
     environment:
-      POSTGRES_DB: wagtailio
-      POSTGRES_USER: wagtailio
-      POSTGRES_PASSWORD: wagtailio
-      PGDATABASE: wagtailio
-      PGUSER: wagtailio
-      PGPASSWORD: wagtailio
+      POSTGRES_DB: wagtailorg
+      POSTGRES_USER: wagtailorg
+      POSTGRES_PASSWORD: wagtailorg
+      PGDATABASE: wagtailorg
+      PGUSER: wagtailorg
+      PGPASSWORD: wagtailorg
       POSTGRES_HOST_AUTH_METHOD: trust
     logging:
       driver: none
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      test: ['CMD-SHELL', 'pg_isready -U wagtailorg']
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
fixes the healthcheck command, and changes the use of `wagtailio` to `wagtailorg` where possible