### PR TITLE
Fix rendering of sub heading on HeadlineBlock template

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/headline/headline.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/headline/headline.html
@@ -6,8 +6,8 @@
 
         <h2 class="headline__heading heading-one">{{ value.heading }}</h2>
 
-        {% if value.subheading %}
-            <p class="headline__subheading intro-big">{{ value.subheading }}</p>
+        {% if value.sub_heading %}
+            <p class="headline__subheading intro-big">{{ value.sub_heading }}</p>
         {% endif %}
 
         {% if value.intro %}


### PR DESCRIPTION
This PR fixes an issue on the Headline Block where the sub heading was not rendered on the template.

The sub heading was not displayed because of a variable name mismatch -- the block definition on the backend has `sub_heading`, while the template had `subheading`.

Monday reference: [#69](https://torchbox.monday.com/boards/1123315381/pulses/1125655150). 