### PR TITLE
Search index fields

### DIFF
--- a/wagtailio/blog/models.py
+++ b/wagtailio/blog/models.py
@@ -7,6 +7,7 @@ from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import FieldPanel, InlinePanel
 from wagtail.fields import StreamField
 from wagtail.models import Orderable, Page
+from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
 from wagtailio.blog.blocks import BlogStoryBlock
@@ -176,6 +177,11 @@ class BlogPage(Page, SocialMediaMixin, CrossPageMixin):
         + CrossPageMixin.panels
         + [FieldPanel("canonical_url")]
     )
+
+    search_fields = Page.search_fields + [
+        index.SearchField("introduction"),
+        index.SearchField("body"),
+    ]
 
     @cached_property
     def related_pages(self):

--- a/wagtailio/core/models/pages.py
+++ b/wagtailio/core/models/pages.py
@@ -3,6 +3,7 @@ from django.db import models
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.fields import RichTextField, StreamField
 from wagtail.models import Page
+from wagtail.search import index
 
 from wagtailmedia.edit_handlers import MediaChooserPanel
 
@@ -101,6 +102,13 @@ class HomePage(SocialMediaMixin, CrossPageMixin, Page):
         Page.promote_panels + SocialMediaMixin.panels + CrossPageMixin.panels
     )
 
+    search_fields = Page.search_fields + [
+        index.SearchField("heading"),
+        index.SearchField("sub_heading"),
+        index.SearchField("intro"),
+        index.SearchField("body"),
+    ]
+
 
 class ContentPage(Page, HeroMixin, SocialMediaMixin, CrossPageMixin):
     template = "patterns/pages/content_page/content_page.html"
@@ -115,3 +123,10 @@ class ContentPage(Page, HeroMixin, SocialMediaMixin, CrossPageMixin):
     promote_panels = (
         Page.promote_panels + SocialMediaMixin.panels + CrossPageMixin.panels
     )
+
+    search_fields = Page.search_fields + [
+        index.SearchField("heading"),
+        index.SearchField("sub_heading"),
+        index.SearchField("intro"),
+        index.SearchField("body"),
+    ]

--- a/wagtailio/developers/models.py
+++ b/wagtailio/developers/models.py
@@ -4,6 +4,7 @@ from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel
 from wagtail.fields import StreamField
 from wagtail.models import Orderable, Page
+from wagtail.search import index
 
 from wagtailio.core.blocks import CodePromoBlock
 from wagtailio.utils.models import CrossPageMixin, SocialMediaMixin
@@ -57,4 +58,8 @@ class DevelopersPage(Page, SocialMediaMixin, CrossPageMixin):
     content_panels = Page.content_panels + [
         FieldPanel("body"),
         InlinePanel("options", label="Options"),
+    ]
+
+    search_fields = Page.search_fields + [
+        index.SearchField("body"),
     ]

--- a/wagtailio/features/models.py
+++ b/wagtailio/features/models.py
@@ -5,6 +5,7 @@ from modelcluster.models import ClusterableModel
 from wagtail.admin.panels import FieldPanel, InlinePanel
 from wagtail.fields import RichTextField, StreamField
 from wagtail.models import Orderable, Page
+from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
 from wagtailmedia.edit_handlers import MediaChooserPanel
@@ -108,4 +109,9 @@ class FeatureIndexPage(Page):
         FieldPanel("features", classname="collapsible"),
         FieldPanel("cta", heading="Call to action"),
         FieldPanel("get_started"),
+    ]
+
+    search_fields = Page.search_fields + [
+        index.SearchField("subheading"),
+        index.SearchField("features"),
     ]

--- a/wagtailio/newsletter/models.py
+++ b/wagtailio/newsletter/models.py
@@ -5,6 +5,7 @@ from django.shortcuts import render
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import RichTextField
 from wagtail.models import Page
+from wagtail.search import index
 
 
 class NewsletterPage(Page):
@@ -18,6 +19,11 @@ class NewsletterPage(Page):
         FieldPanel("body"),
     ]
 
+    search_fields = Page.search_fields + [
+        index.SearchField("intro"),
+        index.SearchField("body"),
+    ]
+
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
         if request.GET.get("email", "false") == "true":
@@ -29,6 +35,11 @@ class NewsletterPage(Page):
 class NewsletterIndexPage(Page):
     intro = RichTextField(blank=True)
     body = RichTextField()
+
+    search_fields = Page.search_fields + [
+        index.SearchField("intro"),
+        index.SearchField("body"),
+    ]
 
     @property
     def newsletters(self):

--- a/wagtailio/packages/models.py
+++ b/wagtailio/packages/models.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from wagtail.admin.panels import FieldPanel, HelpPanel, MultiFieldPanel
 from wagtail.fields import RichTextField
 from wagtail.models import Page
+from wagtail.search import index
 
 from wagtailio.utils.models import CrossPageMixin, SocialMediaMixin
 
@@ -56,6 +57,12 @@ class PackagesPage(Page, SocialMediaMixin, CrossPageMixin):
         FieldPanel("subtitle"),
         FieldPanel("about_title"),
         FieldPanel("about_text"),
+    ]
+
+    search_fields = Page.search_fields + [
+        index.SearchField("subtitle"),
+        index.SearchField("about_title"),
+        index.SearchField("about_text"),
     ]
 
 

--- a/wagtailio/services/models.py
+++ b/wagtailio/services/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from wagtail import blocks, fields
 from wagtail.admin.panels import FieldPanel
 from wagtail.models import Page
+from wagtail.search import index
 
 from wagtailio.services.blocks import SectionBlock
 
@@ -22,4 +23,9 @@ class ServicesPage(Page):
     content_panels = Page.content_panels + [
         FieldPanel("intro"),
         FieldPanel("body"),
+    ]
+
+    search_fields = Page.search_fields + [
+        index.SearchField("intro"),
+        index.SearchField("body"),
     ]

--- a/wagtailio/standardpage/models.py
+++ b/wagtailio/standardpage/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import StreamField
 from wagtail.models import Page
+from wagtail.search import index
 
 from wagtailio.utils.blocks import StoryBlock
 from wagtailio.utils.models import CrossPageMixin, SocialMediaMixin
@@ -20,3 +21,8 @@ class StandardPage(Page, SocialMediaMixin, CrossPageMixin):
     promote_panels = (
         Page.promote_panels + SocialMediaMixin.panels + CrossPageMixin.panels
     )
+
+    search_fields = Page.search_fields + [
+        index.SearchField("introduction"),
+        index.SearchField("body"),
+    ]


### PR DESCRIPTION
This PR updates `Page` models by adding fields to the `search_fields` property, in order for us to be able to search on them. See below for details of the Page models and fields added (in addition to `Page.search_fields`):

## wagtailio/blog/models.py

**BlogPage**

- introduction
- body

## wagtailio/core/models/pages.py

**HomePage**

- heading
- sub_heading
- intro
- body

**ContentPage**

- heading
- sub_heading
- intro
- body

## wagtailio/developers/models.py

**DevelopersPage**

- body

## wagtailio/features/models.py

**FeatureIndexPage**

- subheading
- features

## wagtailio/newsletter/models.py

**NewsletterPage**

- intro
- body

**NewsletterIndexPage**

- intro
- body

## wagtailio/packages/models.py

**PackagesPage**

- subtitle
- about_title
- about_text

## wagtailio/services/models.py

**ServicesPage**

- intro
- body

## wagtailio/standardpage/models.py

**StandardPage**

- introduction
- body

---

Monday reference: [#96](https://torchbox.monday.com/boards/1123315381/pulses/1130743612)