### PR TITLE
Nav fragment caching and renditions cache

### DIFF
--- a/wagtailio/navigation/models.py
+++ b/wagtailio/navigation/models.py
@@ -50,7 +50,6 @@ class MainMenu(ClusterableModel):
         super().save(**kwargs)
 
         if NavigationSettings.objects.filter(main_navigation=self).exists():
-            print("delete")
             cache.delete(make_template_fragment_key("primarynav"))
 
     def __str__(self):

--- a/wagtailio/navigation/models.py
+++ b/wagtailio/navigation/models.py
@@ -1,3 +1,5 @@
+from django.core.cache import cache
+from django.core.cache.utils import make_template_fragment_key
 from django.db import models
 
 from modelcluster.models import ClusterableModel
@@ -19,6 +21,12 @@ class FooterMenu(models.Model):
         FieldPanel("sections"),
     ]
 
+    def save(self, **kwargs):
+        super().save(**kwargs)
+
+        if NavigationSettings.objects.filter(main_navigation=self).exists():
+            cache.delete(make_template_fragment_key("footernav"))
+
     def __str__(self):
         return self.name
 
@@ -28,7 +36,6 @@ class FooterMenu(models.Model):
 
 @register_snippet
 class MainMenu(ClusterableModel):
-
     name = models.CharField(max_length=255)
     menu_sections = StreamField(
         [("menu_section", MainMenuSectionBlock())], use_json_field=True
@@ -38,6 +45,13 @@ class MainMenu(ClusterableModel):
         FieldPanel("name"),
         FieldPanel("menu_sections", classname="collapsible"),
     ]
+
+    def save(self, **kwargs):
+        super().save(**kwargs)
+
+        if NavigationSettings.objects.filter(main_navigation=self).exists():
+            print("delete")
+            cache.delete(make_template_fragment_key("primarynav"))
 
     def __str__(self):
         return self.name
@@ -75,3 +89,12 @@ class NavigationSettings(BaseSiteSetting, ClusterableModel):
         FieldPanel("main_navigation"),
         FieldPanel("footer_navigation"),
     ]
+
+    def save(self, **kwargs):
+        super().save(**kwargs)
+
+        keys = [
+            make_template_fragment_key(key, vary_on=[self.site.pk])
+            for key in ["primarynav", "footernav"]
+        ]
+        cache.delete_many(keys)

--- a/wagtailio/navigation/models.py
+++ b/wagtailio/navigation/models.py
@@ -25,7 +25,11 @@ class FooterMenu(models.Model):
         super().save(**kwargs)
 
         if NavigationSettings.objects.filter(main_navigation=self).exists():
-            cache.delete(make_template_fragment_key("footernav"))
+            cache.delete(
+                make_template_fragment_key(
+                    "footernav", vary_on=[self.site.pk, False, False]
+                )
+            )
 
     def __str__(self):
         return self.name
@@ -50,7 +54,11 @@ class MainMenu(ClusterableModel):
         super().save(**kwargs)
 
         if NavigationSettings.objects.filter(main_navigation=self).exists():
-            cache.delete(make_template_fragment_key("primarynav"))
+            cache.delete(
+                make_template_fragment_key(
+                    "primarynav", vary_on=[self.site.pk, False, False]
+                )
+            )
 
     def __str__(self):
         return self.name
@@ -93,7 +101,9 @@ class NavigationSettings(BaseSiteSetting, ClusterableModel):
         super().save(**kwargs)
 
         keys = [
-            make_template_fragment_key(key, vary_on=[self.site.pk])
+            # The fragment cache varies on:
+            # the current site pk, whether used in preview, or in the pattern library
+            make_template_fragment_key(key, vary_on=[self.site.pk, False, False])
             for key in ["primarynav", "footernav"]
         ]
         cache.delete_many(keys)

--- a/wagtailio/project_styleguide/templates/patterns/includes/menu_footer.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/menu_footer.html
@@ -1,38 +1,42 @@
+{% load wagtailcore_tags cache %}
 {% if footer_navigation %}
-    <nav class="footer-menu" aria-label="Footer menu">
-        <div class="footer-menu__grid grid">
-            {% for section in footer_navigation.sections %}
-                {% with section.value as menu_section %}
-                    <div class="footer-menu__column" data-footer-menu-column>
-                        <div class="footer-menu__column-header">
-                            <button class="footer-menu__toggle" aria-label="Open the {{ menu_section.heading }} menu" aria-expanded="false" aria-controls="{{ menu_section.heading|lower }}-menu" data-footer-menu-toggle>
-                                <svg class="footer-menu__icon footer-menu__icon--open" aria-hidden="true" data-footer-menu-open-icon>
-                                    <use xlink:href="#plus-in-circle"></use>
-                                </svg>
-                                <svg class="footer-menu__icon footer-menu__icon--close" aria-hidden="true" data-footer-menu-close-icon>
-                                    <use xlink:href="#minus-in-circle"></use>
-                                </svg>
-                            </button>
+    {% wagtail_site as current_site %}
+    {% cache 900 footernav current_site.pk is_pattern_library %}
+        <nav class="footer-menu" aria-label="Footer menu">
+            <div class="footer-menu__grid grid">
+                {% for section in footer_navigation.sections %}
+                    {% with section.value as menu_section %}
+                        <div class="footer-menu__column" data-footer-menu-column>
+                            <div class="footer-menu__column-header">
+                                <button class="footer-menu__toggle" aria-label="Open the {{ menu_section.heading }} menu" aria-expanded="false" aria-controls="{{ menu_section.heading|lower }}-menu" data-footer-menu-toggle>
+                                    <svg class="footer-menu__icon footer-menu__icon--open" aria-hidden="true" data-footer-menu-open-icon>
+                                        <use xlink:href="#plus-in-circle"></use>
+                                    </svg>
+                                    <svg class="footer-menu__icon footer-menu__icon--close" aria-hidden="true" data-footer-menu-close-icon>
+                                        <use xlink:href="#minus-in-circle"></use>
+                                    </svg>
+                                </button>
 
-                            <p class="footer-menu__column-heading">{{ menu_section.heading }}</p>
+                                <p class="footer-menu__column-heading">{{ menu_section.heading }}</p>
+                            </div>
+
+                            <ul class="footer-menu__list" id="{{ menu_section.heading|lower }}-menu" data-footer-menu-list>
+                                {% for menu_item in menu_section.links %}
+                                    <li class="footer-menu__item">
+                                        <a class="footer-menu__link" href="{{ menu_item.url }}">{{ menu_item.text }}</a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+
+                            {% if forloop.first %}
+                                <svg class="footer-menu__logo" aria-hidden="true">
+                                    <use xlink:href="#wagtail" />
+                                </svg>
+                            {% endif %}
                         </div>
-
-                        <ul class="footer-menu__list" id="{{ menu_section.heading|lower }}-menu" data-footer-menu-list>
-                            {% for menu_item in menu_section.links %}
-                                <li class="footer-menu__item">
-                                    <a class="footer-menu__link" href="{{ menu_item.url }}">{{ menu_item.text }}</a>
-                                </li>
-                            {% endfor %}
-                        </ul>
-
-                        {% if forloop.first %}
-                            <svg class="footer-menu__logo" aria-hidden="true">
-                                <use xlink:href="#wagtail" />
-                            </svg>
-                        {% endif %}
-                    </div>
-                {% endwith %}
-            {% endfor %}
-        </div>
-    </nav>
+                    {% endwith %}
+                {% endfor %}
+            </div>
+        </nav>
+    {% endcache %}
 {% endif %}

--- a/wagtailio/project_styleguide/templates/patterns/includes/menu_footer.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/menu_footer.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags cache %}
 {% if footer_navigation %}
     {% wagtail_site as current_site %}
-    {% cache 900 footernav current_site.pk is_pattern_library %}
+    {% cache 900 footernav current_site.pk request.is_preview is_pattern_library %}
         <nav class="footer-menu" aria-label="Footer menu">
             <div class="footer-menu__grid grid">
                 {% for section in footer_navigation.sections %}

--- a/wagtailio/project_styleguide/templates/patterns/includes/menu_main.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/menu_main.html
@@ -1,42 +1,44 @@
-{% load wagtailcore_tags %}
-
-<nav class="primary-nav" aria-label="Primary">
-    <ul class="primary-nav__container" data-primary-nav>
-        {% for menu_section in menus %}
-            <li class="primary-nav__item primary-nav__item--is-parent" data-has-subnav>
-                <a class="primary-nav__item-container" data-open-subnav aria-haspopup="true" aria-expanded="false" href="#">
-                    <span class="primary-nav__label">{{ menu_section.name }}</span>
-                    <svg class="primary-nav__icon" aria-hidden="true">
-                        <use xlink:href="#chevron" />
-                    </svg>
-                </a>
-                <ul class="sub-nav" data-subnav>
-                    <li class="sub-nav__item sub-nav__item--back">
-                        <a class="sub-nav__item-link sub-nav__item-link--back" data-subnav-back href="#">&lsaquo; Back</a>
-                    </li>
-                    <li class="sub-nav__links">
-                        <h2 class="sub-nav__heading">{{ menu_section.name }}</h2>
-                        <ul class="sub-nav__links-container">
-                            {% for nav_item in menu_section.nav_items %}
-                                <li class="sub-nav__item">
-                                    <a class="sub-nav__item-link" href="{{ nav_item.url }}" title="{{ nav_item.text }}">
-                                        {% include "patterns/components/icon/icon.html" with icon=nav_item.icon classes="icon-link__svg sub-nav__item-icon icon--relative" %}
-                                        <div class="sub-nav__item-content">
-                                            <h3 class="sub-nav__item-heading">{{ nav_item.text }}</h3>
-                                            <p class="sub-nav__item-description">{{ nav_item.short_description }}</p>
-                                        </div>
-                                    </a>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    </li>
-                    <li class="sub-nav__item sub-nav__item--cta">
-                        {% with menu_section.call_to_action as cta %}
-                            {% include "patterns/components/nav-cta/nav-cta.html" %}
-                        {% endwith %}
-                    </li>
-                </ul>
-            </li>
-        {% endfor %}
-    </ul>
-</nav>
+{% load wagtailcore_tags cache %}
+{% wagtail_site as current_site %}
+{% cache 900 primarynav current_site.pk is_pattern_library %}
+    <nav class="primary-nav" aria-label="Primary">
+        <ul class="primary-nav__container" data-primary-nav>
+            {% for menu_section in menus %}
+                <li class="primary-nav__item primary-nav__item--is-parent" data-has-subnav>
+                    <a class="primary-nav__item-container" data-open-subnav aria-haspopup="true" aria-expanded="false" href="#">
+                        <span class="primary-nav__label">{{ menu_section.name }}</span>
+                        <svg class="primary-nav__icon" aria-hidden="true">
+                            <use xlink:href="#chevron" />
+                        </svg>
+                    </a>
+                    <ul class="sub-nav" data-subnav>
+                        <li class="sub-nav__item sub-nav__item--back">
+                            <a class="sub-nav__item-link sub-nav__item-link--back" data-subnav-back href="#">&lsaquo; Back</a>
+                        </li>
+                        <li class="sub-nav__links">
+                            <h2 class="sub-nav__heading">{{ menu_section.name }}</h2>
+                            <ul class="sub-nav__links-container">
+                                {% for nav_item in menu_section.nav_items %}
+                                    <li class="sub-nav__item">
+                                        <a class="sub-nav__item-link" href="{{ nav_item.url }}" title="{{ nav_item.text }}">
+                                            {% include "patterns/components/icon/icon.html" with icon=nav_item.icon classes="icon-link__svg sub-nav__item-icon icon--relative" %}
+                                            <div class="sub-nav__item-content">
+                                                <h3 class="sub-nav__item-heading">{{ nav_item.text }}</h3>
+                                                <p class="sub-nav__item-description">{{ nav_item.short_description }}</p>
+                                            </div>
+                                        </a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </li>
+                        <li class="sub-nav__item sub-nav__item--cta">
+                            {% with menu_section.call_to_action as cta %}
+                                {% include "patterns/components/nav-cta/nav-cta.html" %}
+                            {% endwith %}
+                        </li>
+                    </ul>
+                </li>
+            {% endfor %}
+        </ul>
+    </nav>
+{% endcache %}

--- a/wagtailio/project_styleguide/templates/patterns/includes/menu_main.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/menu_main.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags cache %}
 {% wagtail_site as current_site %}
-{% cache 900 primarynav current_site.pk is_pattern_library %}
+{% cache 900 primarynav current_site.pk request.is_preview is_pattern_library %}
     <nav class="primary-nav" aria-label="Primary">
         <ul class="primary-nav__container" data-primary-nav>
             {% for menu_section in menus %}

--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -295,6 +295,8 @@ if REDIS_URL:
             "OPTIONS": redis_options,
         },
     }
+
+    DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True
 else:
     CACHES = {
         "default": {


### PR DESCRIPTION
Builds on #285 and adds template fragment cache for main and footer nav.

The cache is cleared when the navigation settings is saved. It is also cleared when one saves the main or footer nav snippet that is in use.

Note: using snippets for main/footer nav so as to implement previews now that we are on Wagtail 4