### PR TITLE
Fix get started block links

### DIFF
--- a/wagtailio/core/blocks.py
+++ b/wagtailio/core/blocks.py
@@ -409,13 +409,8 @@ class GetStartedItem(blocks.StructBlock):
 
         return struct_value
 
-    def get_context(self, value, parent_context=None):
-        context = super().get_context(value, parent_context=parent_context)
-        if value["page"]:
-            context["value"]["url"] = value["page"].get_url
-        else:
-            context["value"]["url"] = value["external_link"]
-        return context
+    class Meta:
+        template = "patterns/components/icon-link/icon-link.html"
 
 
 class GetStartedBlock(blocks.StructBlock):

--- a/wagtailio/project_styleguide/templates/patterns/components/get-started/get-started.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/get-started/get-started.html
@@ -1,3 +1,4 @@
+{% load wagtailcore_tags %}
 <div class="get-started grid">
     {% if value.heading %}
         <h2 class="get-started__heading heading-one">{{ value.heading }}</h2>
@@ -7,7 +8,7 @@
         <ul class="get-started__list">
             {% for item in value.items %}
                 <li class="get-started__list-item">
-                    {% include "patterns/components/icon-link/icon-link.html" with value=item %}
+                    {% include_block item %}
                 </li>
             {% endfor %}
         </ul>

--- a/wagtailio/project_styleguide/templates/patterns/components/icon-link/icon-link.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/icon-link/icon-link.html
@@ -1,4 +1,6 @@
-<a class="icon-link" href="{{ value.url }}">
+{% load wagtailcore_tags %}
+{# note: the prefered way of generating page urls is via pageurl so as to pass the request and therefore take advantage of the site-level URL information #}
+<a class="icon-link" href="{% if value.url %}{{ value.url }}{% elif value.page %}{% pageurl value.page %}{% elif value.external_link %}{{ value.external_link }}{% endif %}">
     {% include "patterns/components/icon/icon.html" with icon=value.icon classes="icon-link__svg" %}
 
     <div class="icon-link__content">

--- a/wagtailio/project_styleguide/templates/patterns/components/nav-cta/nav-cta.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/nav-cta/nav-cta.html
@@ -1,4 +1,5 @@
-<a class="nav-cta" href="{{ cta.url }}">
+{% load wagtailcore_tags %}
+<a class="nav-cta" href="{% if cta.cta_url %}{{ cta.cta_url }}{% elif cta.cta_page %}{% pageurl cta.cta_page %}{% endif %}">
     <svg class="nav-cta__icon" aria-hidden="true">
         <use xlink:href="#{{ cta.icon }}" />
     </svg>

--- a/wagtailio/project_styleguide/templates/patterns/includes/menu_footer.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/menu_footer.html
@@ -23,7 +23,7 @@
                             <ul class="footer-menu__list" id="{{ menu_section.heading|lower }}-menu" data-footer-menu-list>
                                 {% for menu_item in menu_section.links %}
                                     <li class="footer-menu__item">
-                                        <a class="footer-menu__link" href="{{ menu_item.url }}">{{ menu_item.text }}</a>
+                                        <a class="footer-menu__link" href="{% if menu_item.cta_url %}{{ menu_item.cta_url }}{% elif menu_item.cta_page %}{% pageurl menu_item.cta_page %}{% endif %}">{{ menu_item.text }}</a>
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/wagtailio/project_styleguide/templates/patterns/includes/menu_get_started.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/menu_get_started.html
@@ -1,3 +1,4 @@
+{% load wagtailcore_tags %}
 {% if get_started_menu %}
     <div class="modal modal--get-started micromodal-slide" id="get-started-menu" aria-hidden="true">
         <div class="modal__overlay" tabindex="-1" data-micromodal-close>
@@ -19,7 +20,7 @@
                             <ul class="modal__grid modal__grid--get-started">
                                 {% for menu_item in get_started.items %}
                                     <li class="modal__grid-item">
-                                        {% include "patterns/components/icon-link/icon-link.html" with value=menu_item %}
+                                        {% include_block menu_item %}
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/wagtailio/project_styleguide/templates/patterns/includes/menu_main.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/menu_main.html
@@ -20,7 +20,7 @@
                             <ul class="sub-nav__links-container">
                                 {% for nav_item in menu_section.nav_items %}
                                     <li class="sub-nav__item">
-                                        <a class="sub-nav__item-link" href="{{ nav_item.url }}" title="{{ nav_item.text }}">
+                                        <a class="sub-nav__item-link" href="{% if nav_item.cta_url %}{{ nav_item.cta_url }}{% elif nav_item.cta_page %}{% pageurl nav_item.cta_page %}{% endif %}" title="{{ nav_item.text }}">
                                             {% include "patterns/components/icon/icon.html" with icon=nav_item.icon classes="icon-link__svg sub-nav__item-icon icon--relative" %}
                                             <div class="sub-nav__item-content">
                                                 <h3 class="sub-nav__item-heading">{{ nav_item.text }}</h3>


### PR DESCRIPTION
This PR fixes the links in the "Get started" block, and updates the nav to make use of `pageurl`