### PR TITLE
Fix modal positioning and contrast issues

### DIFF
--- a/wagtailio/static/sass/components/_modal.scss
+++ b/wagtailio/static/sass/components/_modal.scss
@@ -96,6 +96,12 @@
     &__close-button {
         display: block;
         margin-left: auto;
+
+        svg {
+            @media (forced-colors: active) {
+                fill: ButtonText;
+            }
+        }
     }
 
     &__close-icon {

--- a/wagtailio/static/sass/components/_modal.scss
+++ b/wagtailio/static/sass/components/_modal.scss
@@ -21,6 +21,10 @@
     }
 
     &--search {
+        #{$root}__overlay {
+            align-items: flex-start;
+        }
+
         #{$root}__container {
             max-width: 850px;
             overflow: visible;
@@ -51,13 +55,13 @@
     }
 
     &__overlay {
+        @include z-index(modal);
         position: fixed;
         inset: 0;
         background: $color--off-black-30;
         display: flex;
         justify-content: center;
-        align-items: flex-start;
-        z-index: 10;
+        align-items: center;
     }
 
     &__container {
@@ -69,7 +73,6 @@
         overflow-y: auto;
         box-sizing: border-box;
         width: calc(100% - 40px);
-        inset: 140px 0;
         position: relative;
     }
 

--- a/wagtailio/static/sass/components/_modal.scss
+++ b/wagtailio/static/sass/components/_modal.scss
@@ -74,6 +74,7 @@
         box-sizing: border-box;
         width: calc(100% - 40px);
         position: relative;
+        border: 2px solid transparent;
     }
 
     &__grid {


### PR DESCRIPTION
## Description

This fixes the z-index of the modal to avoid overlapping with the main content. Not sure whether the page is supposed to be scrollable when a modal is open, but I still keep the current behaviour in this PR.

I also don't know whether the modal is supposed to be off-center (a bit slightly to the top), but I made it centered in this PR.

### Before

https://user-images.githubusercontent.com/6379424/198681142-31660e9d-bea3-40b6-b672-d5e5ca598ce1.mov

### After

https://user-images.githubusercontent.com/6379424/198682446-ae0749ff-5ba0-4fd5-bef6-5000124fc0d9.mov