### PR TITLE
Fix empty heading in card blocks

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/card_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/card_block.html
@@ -1,6 +1,8 @@
 <div class="card {% if classes %}{{ classes }}{% endif %}">
     {% include "patterns/components/meta/meta.html" with classes="card__meta" %}
-    <h4 class="card__heading heading-three">{{ value.heading }}</h4>
+    {% if value.heading %}
+        <h4 class="card__heading heading-three">{{ value.heading }}</h4>
+    {% endif %}
     {% if value.description %}
         <div class="card__description mini-meta">
             {{ value.description }}

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_card_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_card_block.html
@@ -16,7 +16,9 @@ The reason for the separation is because of differing context variable names, fo
 {% endif %}
 {% include "patterns/components/meta/meta.html" with classes="logo-card__meta" %}
 
-<h4 class="logo-card__heading teaser-heading">{{ value.text }}</h4>
+{% if value.text %}
+    <h4 class="logo-card__heading teaser-heading">{{ value.text }}</h4>
+{% endif %}
 
 {% if value.description %}
     <div class="logo-card__description">{{ value.description|richtext }}</div>

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_cards_list_block.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_cards_list_block.yaml
@@ -1,27 +1,27 @@
 context:
   value:
     cards:
-      - heading: Senior Python Developer
+      - text: Senior Python Developer
         description: Take the lead on building web apps, helping to improve Wagtail and working in a multidisciplinary team environment to solve complex problems.
         meta_icon: location-pin
         meta_text: UK, US, Philippines & Remote
         logo: fake
         publication_date: false
-      - heading: Senior Wagtail Developer
+      - text: Senior Wagtail Developer
         description: By joining our Wagtail product team you'll learn from the likes of Django Fellows
         meta_icon: location-pin
         meta_text: Philippines
         logo: fake
         link_url: 'https://www.python.org/'
         publication_date: false
-      - heading: Software Developer Intern
+      - text: Software Developer Intern
         description: An exciting opportunity to build a modern and completely different cloud-based app hosting platform...
         meta_icon: location-pin
         meta_text: UK, US, Philippines & Remote
         logo: fake
         link_url: 'https://reactjs.org/'
         publication_date: false
-      - heading: Product Marketing Intern
+      - text: Product Marketing Intern
         description: If you are looking for an opportunity to get hands-on experience in defining a market and launch a product, this is the opportunity for you!
         meta_icon: location-pin
         meta_text: Philippines

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/related_page_card_block.html
@@ -12,7 +12,9 @@ The reason for the separation is because of differing context variable names, fo
 <a href="{{ value.url }}" class="logo-card {% if classes %}{{ classes }}{% endif %}">
     {% include "patterns/components/meta/meta.html" with classes="logo-card__meta" %}
 
-    <h4 class="logo-card__heading teaser-heading">{{ value.title }}</h4>
+    {% if value.title %}
+        <h4 class="logo-card__heading teaser-heading">{{ value.title }}</h4>
+    {% endif %}
 
     <div class="logo-card__description">{{ value.introduction }}</div>
 

--- a/wagtailio/static/sass/components/_logo-card.scss
+++ b/wagtailio/static/sass/components/_logo-card.scss
@@ -19,12 +19,13 @@
     }
 
     &__heading {
-        margin-bottom: 10px;
         transition: color .3s ease;
+        margin-bottom: 0;
     }
 
     &__description {
         color: $color--grey;
+        margin-top: 10px;
         padding-bottom: 20px;
 
         @include media-query(large) {


### PR DESCRIPTION
The pattern library demo for `logo_cards_list_block` is missing the headings:

<img width="832" alt="image" src="https://user-images.githubusercontent.com/6379424/199006579-8dff57e5-811c-4f07-a355-2dbc88a6183c.png">

It's because the data incorrectly supplies the headings under a `heading` key:

https://github.com/wagtail/wagtail.org/blob/1cf4e4ee322f96e50cb0f1b39eda88891b737c45/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_cards_list_block.yaml#L4

When they should be `text`:

https://github.com/wagtail/wagtail.org/blob/1cf4e4ee322f96e50cb0f1b39eda88891b737c45/wagtailio/core/blocks.py#L104-L105

---

I also added a commit to not render the `<h4>` element if the heading is empty. We already do this in several other places, e.g.

https://github.com/wagtail/wagtail.org/blob/1cf4e4ee322f96e50cb0f1b39eda88891b737c45/wagtailio/project_styleguide/templates/patterns/components/streamfields/cards/logo_cards_list_block.html#L2-L6

so I think it's worth applying the check to the card blocks' templates.