### PR TITLE
Add `<legend>` element to `<fieldset>` for feature index block

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/features/feature_index_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/features/feature_index_block.html
@@ -6,7 +6,7 @@
         <legend class="u-sr-only">{% trans 'Filter features by category' %}</legend>
         <div class="features__filter-wrap">
             <input type="checkbox" id="all" name="all" data-feature-filter-all checked>
-            <label class="mini-meta" for="all">All</label>
+            <label class="mini-meta" for="all">{% trans 'All' %}</label>
         </div>
         {% for category in value.categories %}
             <div class="features__filter-wrap">

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/features/feature_index_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/features/feature_index_block.html
@@ -1,8 +1,9 @@
-{% load wagtailcore_tags %}
+{% load i18n wagtailcore_tags %}
 
 <div class="grid">
     {# Filters #}
     <fieldset class="features__filters">
+        <legend class="u-sr-only">{% trans 'Filter features by category' %}</legend>
         <div class="features__filter-wrap">
             <input type="checkbox" id="all" name="all" data-feature-filter-all checked>
             <label class="mini-meta" for="all">All</label>


### PR DESCRIPTION
Each `<fieldset>` element should have a corresponding `<legend>` element to describe what the set of fields is about.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset

Not sure if we'd like to use `{% trans %}` or put it [in the block itself](https://github.com/wagtail/wagtail.org/blob/next/wagtailio/features/blocks.py#L60) (as a `heading`  `CharBlock` maybe). However, the block currently seems to be quite specific to "Features" (instead of being a generic categorised block), so I think it's fine to put it in the template.