### PR TITLE
Add canonical link tags

### DIFF
--- a/wagtailio/newsletter/templates/newsletter/newsletter_page.html
+++ b/wagtailio/newsletter/templates/newsletter/newsletter_page.html
@@ -844,15 +844,19 @@
             }
         </style>
 
-        {% if not DEBUG and not is_email %}
-            <!-- Google Tag Manager -->
-            <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','GTM-5XDDLH');
-            </script>
-            <!-- End Google Tag Manager -->
+        {% if not DEBUG %}
+            <link rel="canonical" href="{{ page.full_url }}" />
+
+            {% if not is_email %}
+                <!-- Google Tag Manager -->
+                <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+                    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-5XDDLH');
+                </script>
+                <!-- End Google Tag Manager -->
+            {% endif %}
         {% endif %}
     </head>
     <body>

--- a/wagtailio/project_styleguide/templates/patterns/base_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/base_page.html
@@ -7,7 +7,9 @@
     <meta name="description" content="{% firstof page.social_text page.listing_intro %}" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    {% if page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}" />{% endif %}
+    {% if page.canonical_url or page.full_url %}
+        <link rel="canonical" href="{% firstof page.canonical_url page.full_url %}" />
+    {% endif %}
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@wagtailcms" />


### PR DESCRIPTION
Right now the `base_page.html` template only adds the tag if the page has a `canonical_url`, which currently only exists in the `BlogPage` model:
https://github.com/wagtail/wagtail.org/blob/76b2b90c789db002ad2ee5662dcad83871c49dde/wagtailio/blog/models.py#L126-L129

As per our SEO recommendations, we should add this tag sitewide. This PR implements it by falling back to the page's `full_url` if the `canonical_url` field is unset. From a quick look, it seems that all of our pages (except This New in Wagtail newsletter pages) extend the `base_page.html` template, so I think this should cover the whole site.

Templates that extend from `base_page.html` but isn't rendered with a Wagtail `Page` instance, e.g. 500 and 404 pages, will not have the canonical tag.

I handled the `newsletter_page.html` template separately, not sure if it's worth adding a canonical tag but it probably won't hurt. (Enable "Hide whitespace" when reviewing this PR to hide noise for this template.)