### PR TITLE
Implement focus trap on mobile navigation menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "focus-trap": "^7.0.0",
         "micromodal": "^0.4.10"
       },
       "devDependencies": {
@@ -3174,6 +3175,14 @@
       "version": "3.2.6",
       "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
       "dev": true
+    },
+    "node_modules/focus-trap": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.0.0.tgz",
+      "integrity": "sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==",
+      "dependencies": {
+        "tabbable": "^6.0.0"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.1",
@@ -7045,6 +7054,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.1.tgz",
+      "integrity": "sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA=="
     },
     "node_modules/table": {
       "version": "6.8.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "webpack-manifest-plugin": "^5.0.0"
   },
   "dependencies": {
+    "focus-trap": "^7.0.0",
     "micromodal": "^0.4.10"
   }
 }

--- a/wagtailio/project_styleguide/templates/patterns/includes/header.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/header.html
@@ -21,10 +21,6 @@
             {% main_navigation %}
         </div>
 
-        <div class="header__nav header__nav--mobile" data-mobile-menu>
-            {% main_navigation %}
-        </div>
-
         <div class="header__search">
             {# Desktop Search #}
             <button class="header__button header__button--search u-desktop-only" aria-controls="site-search-modal" aria-label="Open the search" data-site-search-desktop>
@@ -51,6 +47,10 @@
                 <span class="burger__line"></span>
                 <span class="burger__line"></span>
             </button>
+        </div>
+
+        <div class="header__nav header__nav--mobile" data-mobile-menu>
+            {% main_navigation %}
         </div>
 
         {% if settings.navigation.NavigationSettings.get_started_menu %}

--- a/wagtailio/static/js/components/mobile-menu.js
+++ b/wagtailio/static/js/components/mobile-menu.js
@@ -1,3 +1,5 @@
+import { createFocusTrap } from 'focus-trap';
+
 class MobileMenu {
     static selector() {
         return '[data-mobile-menu-toggle]';
@@ -11,13 +13,22 @@ class MobileMenu {
         this.state = {
             open: false,
         };
-
+        this.focusTrap = createFocusTrap([
+            this.node.parentElement,
+            this.mobileMenu,
+        ]);
         this.bindEventListeners();
     }
 
     bindEventListeners() {
         this.node.addEventListener('click', () => {
             this.toggle();
+        });
+
+        // Allow pressing Escape to close
+        this.mobileMenu.addEventListener('keydown', (e) => {
+            if (e.key !== 'Escape') return;
+            this.close();
         });
     }
 
@@ -43,13 +54,14 @@ class MobileMenu {
         this.body.classList.add('no-scroll');
         this.mobileMenu.classList.add('is-visible');
 
-        const siteWideAlert = document.querySelector('.sitewide-alert')
+        const siteWideAlert = document.querySelector('.sitewide-alert');
         if (siteWideAlert) {
             // adjust for the site-wider alert height
             this.mobileMenu.style.marginTop = siteWideAlert.clientHeight + 'px';
         }
 
         this.state.open = true;
+        this.focusTrap.activate();
     }
 
     close() {
@@ -59,6 +71,7 @@ class MobileMenu {
         this.mobileMenu.classList.remove('is-visible');
 
         this.state.open = false;
+        this.focusTrap.deactivate();
     }
 }
 

--- a/wagtailio/static/js/components/mobile-sub-menu.js
+++ b/wagtailio/static/js/components/mobile-sub-menu.js
@@ -1,3 +1,5 @@
+import { createFocusTrap } from 'focus-trap';
+
 class MobileSubMenu {
     static selector() {
         return '[data-mobile-menu] [data-open-subnav]';
@@ -7,6 +9,7 @@ class MobileSubMenu {
         this.node = node;
         this.subnav = this.node.nextElementSibling;
         this.backLink = this.subnav.querySelector('[data-subnav-back]');
+        this.focusTrap = createFocusTrap(this.subnav);
         this.bindEventListeners();
     }
 
@@ -19,14 +22,30 @@ class MobileSubMenu {
         // Click back button to close it
         this.backLink.addEventListener('click', (e) => {
             e.preventDefault();
-            this.subnav.classList.remove('is-visible');
-            this.node.setAttribute('aria-expanded', 'false');
+            this.close();
+        });
+
+        // Allow pressing Escape to close
+        this.subnav.addEventListener('keydown', (e) => {
+            if (e.key !== 'Escape') return;
+            this.close();
         });
     }
 
     open() {
         this.subnav.classList.add('is-visible');
         this.node.setAttribute('aria-expanded', 'true');
+
+        // Wait for elements to become visible before activating focus trap
+        setTimeout(() => {
+            this.focusTrap.activate();
+        }, 300);
+    }
+
+    close() {
+        this.subnav.classList.remove('is-visible');
+        this.node.setAttribute('aria-expanded', 'false');
+        this.focusTrap.deactivate();
     }
 }
 

--- a/wagtailio/static/sass/layout/_header.scss
+++ b/wagtailio/static/sass/layout/_header.scss
@@ -60,6 +60,7 @@
             width: 100%;
             height: 100%;
             background-color: $color--white;
+            visibility: hidden;
             transform: translate3d(100%,0,0);
             transition: transform $transition;
 
@@ -72,6 +73,7 @@
             }
 
             &.is-visible {
+                visibility: visible;
                 transform: translateZ(0);
                 overflow-y: scroll;
             }


### PR DESCRIPTION
This PR adds a focus trap to the navigation menu on mobile devices to prevent tabbing outside of the menu and thus focusing on elements that are covered by the menu.