### PR TITLE
Use a slightly more efficient sitemap

### DIFF
--- a/wagtailio/urls.py
+++ b/wagtailio/urls.py
@@ -19,6 +19,7 @@ from wagtailio.newsletter.feeds import NewsLetterIssuesFeed
 from wagtailio.search.views import search
 from wagtailio.sitewide_alert import urls as sitewide_alert_urls
 from wagtailio.utils.cache import get_default_cache_control_decorator
+from wagtailio.utils.sitemap_generator import Sitemap
 from wagtailio.utils.views import error_404, error_500, favicon, robots
 
 # Private URLs are not meant to be cached.
@@ -33,7 +34,7 @@ private_urlpatterns = [
 urlpatterns = [
     path("newsletter/feed/", NewsLetterIssuesFeed(), name="newsletter_feed"),
     path("blog/feed/", BlogFeed(), name="blog_feed"),
-    path("sitemap.xml", sitemap),
+    path("sitemap.xml", sitemap, {"sitemaps": {"wagtail": Sitemap}}),
     path("favicon.ico", favicon),
     path("robots.txt", robots),
 ]

--- a/wagtailio/utils/sitemap_generator.py
+++ b/wagtailio/utils/sitemap_generator.py
@@ -1,0 +1,16 @@
+from wagtail.contrib.sitemaps import Sitemap as WagtailSitemap
+
+
+class Sitemap(WagtailSitemap):
+    def items(self):
+        # No need for a .specific() call
+        # Note, if modifying the get_sitemap_urls() method on any of the custom page
+        # types, then you need to re-add .defer_streamfields().specific() at the end of
+        # this call, or better yet, default back to Wagtail's sitemap
+        return (
+            self.get_wagtail_site()
+            .root_page.get_descendants(inclusive=True)
+            .live()
+            .public()
+            .order_by("path")
+        )


### PR DESCRIPTION
Since we're only outputting the URL and last modified date (`last_published_at` or `latest_revision_created_at`), we don't need the specific objects

(red - before, green - after)
![Screenshot 2022-11-07 at 19 40 23](https://user-images.githubusercontent.com/31622/200400267-b09a6076-f222-4579-bf5c-00dab6e2d83f.png)
