### PR TITLE
Close desktop sub-menus when pressing Esc

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/includes/menu_main.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/menu_main.html
@@ -5,15 +5,15 @@
         <ul class="primary-nav__container" data-primary-nav>
             {% for menu_section in menus %}
                 <li class="primary-nav__item primary-nav__item--is-parent" data-has-subnav>
-                    <a class="primary-nav__item-container" data-open-subnav aria-haspopup="true" aria-expanded="false" href="#">
+                    <button class="primary-nav__item-container" data-open-subnav aria-expanded="false">
                         <span class="primary-nav__label">{{ menu_section.name }}</span>
                         <svg class="primary-nav__icon" aria-hidden="true">
                             <use xlink:href="#chevron" />
                         </svg>
-                    </a>
+                    </button>
                     <ul class="sub-nav" data-subnav>
                         <li class="sub-nav__item sub-nav__item--back">
-                            <a class="sub-nav__item-link sub-nav__item-link--back" data-subnav-back href="#">&lsaquo; Back</a>
+                            <button class="sub-nav__item-link sub-nav__item-link--back" data-subnav-back>&lsaquo; Back</button>
                         </li>
                         <li class="sub-nav__links">
                             <h2 class="sub-nav__heading">{{ menu_section.name }}</h2>

--- a/wagtailio/project_styleguide/templates/patterns/pages/home/home_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/home/home_page.html
@@ -40,7 +40,9 @@
     {% if page.video %}
         <div class="home-embed">
             <div class="responsive-object" style="padding-bottom: 56.25%;">
-                <video {% if page.autoplay_video %}autoplay loop muted tabindex="0" data-looping-video{% else %}controls{% endif %}>
+                {# Bare-minimum alternative text for the homepage video. To be replaced with YouTube. #}
+                <p id="home-embed-video-description" class="u-sr-only">Promotional homepage video</p>
+                <video aria-describedby="home-embed-video-description" {% if page.autoplay_video %}autoplay loop muted tabindex="0" data-looping-video aria-label="Click to pause/play"{% else %}controls{% endif %}>
                     {% for source in page.video.sources %}
                         <source type="{{ source.type }}" src="{{ source.src }}">
                     {% endfor %}

--- a/wagtailio/static/js/components/desktop-close-menus.js
+++ b/wagtailio/static/js/components/desktop-close-menus.js
@@ -19,7 +19,7 @@ class DesktopCloseMenus {
         let close = true;
 
         this.allPrimaryNavs.forEach((item) => {
-            if (item.contains(e.target)) {
+            if (e && item.contains(e.target)) {
                 // don't close the menus if we are clicking anywhere on the primary navigation
                 close = false;
             }
@@ -43,6 +43,12 @@ class DesktopCloseMenus {
                 this.closeMenus(e);
             });
         }
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                this.closeMenus();
+            };
+        });
     }
 }
 

--- a/wagtailio/static/sass/components/_primary-nav.scss
+++ b/wagtailio/static/sass/components/_primary-nav.scss
@@ -58,11 +58,6 @@
         &:hover,
         &.active {
             color: $color--primary;
-
-
-            #{$root}__icon {
-                color: $color--primary;
-            }
         }
     }
 
@@ -101,7 +96,7 @@
     &__icon {
         height: 12px;
         width: 12px;
-        fill: $color--cool-grey;
+        fill: $color--primary;
         transition: fill $transition;
         transform: rotate(-90deg);
 
@@ -111,8 +106,6 @@
         }
 
         .active & {
-            fill: $color--primary;
-
             @media only screen and (min-width: $header-desktop) {
                 transform: rotate(180deg);
             }

--- a/wagtailio/static/sass/components/_primary-nav.scss
+++ b/wagtailio/static/sass/components/_primary-nav.scss
@@ -54,6 +54,8 @@
         justify-content: space-between;
         text-decoration: none;
         color: $color--off-black;
+        padding: 0;
+        width: 100%;
 
         &:hover,
         &.active {

--- a/wagtailio/static/sass/components/_sub-nav.scss
+++ b/wagtailio/static/sass/components/_sub-nav.scss
@@ -187,6 +187,7 @@
             line-height: 1;
             padding: 10px 0;
             font-weight: $weight--regular;
+            width: 100%;
         }
     }
 


### PR DESCRIPTION
Fixes:

- #304 & #306 (same fix)
- #305
- #307
- #308
- …and one item from our accessibility audit (alt text for the video).

There isn’t that much in common between those issues, just grouping them so it’s easier to test everything in one go.