### PR TITLE
Remove extra aria-label from hard-coded footer links

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/includes/footer.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/footer.html
@@ -7,7 +7,7 @@
             {# Links #}
             <ul class="footer__links-wrap">
                 <li class="footer__link-item">
-                    <a class="footer__icon-link footer__icon-link--sponsor" href="/sponsor" aria-label="Sponsor Wagtail">
+                    <a class="footer__icon-link footer__icon-link--sponsor" href="/sponsor">
                         <svg class="footer__icon" aria-hidden="true">
                             <use xlink:href="#money"></use>
                         </svg>
@@ -18,7 +18,7 @@
                     </a>
                 </li>
                 <li class="footer__link-item">
-                    <a class="footer__icon-link footer__icon-link--contribute" href="https://docs.wagtail.org/en/stable/contributing/index.html#contributing-to-wagtail" aria-label="Contribute code">
+                    <a class="footer__icon-link footer__icon-link--contribute" href="https://docs.wagtail.org/en/stable/contributing/index.html#contributing-to-wagtail">
                         <svg class="footer__icon" aria-hidden="true">
                             <use xlink:href="#code-file"></use>
                         </svg>


### PR DESCRIPTION
It’s not appropriate for `aria-label` to contain _less_ content than the equivalent text without it