### PR TITLE
Use secure cookies for session and CSRF

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -6,4 +6,4 @@ build:
 release:
   image: web
   command:
-    - django-admin createcachetable && django-admin migrate --noinput
+    - django-admin check --deploy && django-admin createcachetable && django-admin migrate --noinput

--- a/wagtailio/settings/production.py
+++ b/wagtailio/settings/production.py
@@ -19,6 +19,13 @@ except ValueError:
 
 MANIFEST_LOADER["cache"] = True  # noqa
 
+# Use secure cookies for the session and CSRF cookies.
+# If these are set to True, the cookies will be marked as “secure”, which means
+# browsers may ensure that the cookies are only sent under an HTTPS connection.
+# https://docs.djangoproject.com/en/4.1/ref/settings/#session-cookie-secure
+# https://docs.djangoproject.com/en/4.1/ref/settings/#csrf-cookie-secure
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
 
 try:
     from .local import *  # noqa


### PR DESCRIPTION
`python manage.py check --deploy` output with our current setup:

```
WARNINGS:
?: (security.W004) You have not set a value for the SECURE_HSTS_SECONDS setting. If your entire site is served only over SSL, you may want to consider setting a value and enabling HTTP Strict Transport Security. Be sure to read the documentation first; enabling HSTS carelessly can cause serious, irreversible problems.
?: (security.W012) SESSION_COOKIE_SECURE is not set to True. Using a secure-only session cookie makes it more difficult for network traffic sniffers to hijack user sessions.
?: (security.W016) You have 'django.middleware.csrf.CsrfViewMiddleware' in your MIDDLEWARE, but you have not set CSRF_COOKIE_SECURE to True. Using a secure-only CSRF cookie makes it more difficult for network traffic sniffers to steal the CSRF token.
```

P.s. `SECURE_HSTS_SECONDS` already exists and just needs to be enabled through env vars:

https://github.com/wagtail/wagtail.org/blob/7db477f841f15b32332ed7c3d07fa4babd02b02b/wagtailio/settings/base.py#L365-L377

~~but as this is *the* `wagtail.org` website, we need to be careful as it could potentially cause issues if we have subdomains that are not served under HTTPS.~~ It's enabled now.