### PR TITLE
Updates to the streamfield spacing mixin and subsequent adjustments

### DIFF
--- a/wagtailio/static/sass/abstracts/_mixins.scss
+++ b/wagtailio/static/sass/abstracts/_mixins.scss
@@ -30,12 +30,8 @@
 }
 
 // Streamfield spacing
-@mixin sf-spacing() {
-    margin-bottom: 50px;
-
-    @include media-query(large) {
-        margin-bottom: 150px;
-    }
+@mixin sf-spacing($multiple) {
+    margin-bottom: 25px * $multiple;
 }
 
 // Adds coloured offset background on the right

--- a/wagtailio/static/sass/components/_backers.scss
+++ b/wagtailio/static/sass/components/_backers.scss
@@ -1,5 +1,5 @@
 .backers {
-    @include sf-spacing();
+    @include sf-spacing(2);
     grid-column: 2 / span 2;
 
     @include media-query(medium) {

--- a/wagtailio/static/sass/components/_card-grid.scss
+++ b/wagtailio/static/sass/components/_card-grid.scss
@@ -2,7 +2,7 @@
     display: grid;
 
     grid-column: 2 / span 2;
-    @include sf-spacing();
+    @include sf-spacing(2);
 
     @include media-query(medium) {
         grid-column: 2 / span 3;

--- a/wagtailio/static/sass/components/_cta-block.scss
+++ b/wagtailio/static/sass/components/_cta-block.scss
@@ -1,5 +1,5 @@
 .cta-block {
-  @include sf-spacing();
+  @include sf-spacing(2);
   grid-column: 2 / span 3;
 
   @include media-query(large) {

--- a/wagtailio/static/sass/components/_cta.scss
+++ b/wagtailio/static/sass/components/_cta.scss
@@ -1,6 +1,6 @@
 .cta {
     $root: &;
-    @include sf-spacing();
+    @include sf-spacing(3);
     padding: 30px;
     text-decoration: none;
     display: flex;

--- a/wagtailio/static/sass/components/_document.scss
+++ b/wagtailio/static/sass/components/_document.scss
@@ -1,5 +1,5 @@
 .document {
-    @include sf-spacing();
+    @include sf-spacing(2);
     grid-column: 2 / span 2;
     color: $color--teal;
     transition: color 0.3s;

--- a/wagtailio/static/sass/components/_embed.scss
+++ b/wagtailio/static/sass/components/_embed.scss
@@ -1,5 +1,5 @@
 .embed {
-    @include sf-spacing();
+    @include sf-spacing(2);
     grid-column: 2 / span 2;
 
     @include media-query(medium) {

--- a/wagtailio/static/sass/components/_features.scss
+++ b/wagtailio/static/sass/components/_features.scss
@@ -1,5 +1,5 @@
 .features {
-    @include sf-spacing();
+    @include sf-spacing(2);
 
     &__filters {
         display: flex;

--- a/wagtailio/static/sass/components/_headline.scss
+++ b/wagtailio/static/sass/components/_headline.scss
@@ -1,6 +1,6 @@
 .headline {
     $root: &;
-    @include sf-spacing();
+    @include sf-spacing(2);
     position: relative;
     padding: 80px 0 0;
 

--- a/wagtailio/static/sass/components/_hero.scss
+++ b/wagtailio/static/sass/components/_hero.scss
@@ -1,6 +1,6 @@
 .hero {
     $root: &;
-    @include sf-spacing();
+    @include sf-spacing(6);
     position: relative;
     grid-column: 2 / span 2;
 

--- a/wagtailio/static/sass/components/_highlight.scss
+++ b/wagtailio/static/sass/components/_highlight.scss
@@ -1,6 +1,6 @@
 .highlight {
     $root: &;
-    @include sf-spacing();
+    @include sf-spacing(2);
     align-items: center;
     grid-auto-flow: dense;
 

--- a/wagtailio/static/sass/components/_icon-bullet.scss
+++ b/wagtailio/static/sass/components/_icon-bullet.scss
@@ -1,10 +1,6 @@
 .icon-bullet {
     margin-bottom: 50px;
 
-    @include media-query(medium) {
-        margin-bottom: 100px;
-    }
-
     &__svg {
         grid-column: 2 / span 2;
         width: 60px;

--- a/wagtailio/static/sass/components/_icon-bullets.scss
+++ b/wagtailio/static/sass/components/_icon-bullets.scss
@@ -1,4 +1,4 @@
 .icon-bullets {
-    @include sf-spacing();
+    @include sf-spacing(2);
     padding: 0;
 }

--- a/wagtailio/static/sass/components/_image.scss
+++ b/wagtailio/static/sass/components/_image.scss
@@ -1,5 +1,5 @@
 .image {
-    @include sf-spacing();
+    @include sf-spacing(2);
     grid-column: 2 / span 2;
 
     @include media-query(medium) {

--- a/wagtailio/static/sass/components/_logo-card-grid.scss
+++ b/wagtailio/static/sass/components/_logo-card-grid.scss
@@ -1,5 +1,5 @@
 .logo-card-grid {
-    @include sf-spacing();
+    @include sf-spacing(2);
 
     &__heading {
         margin-bottom: 20px;

--- a/wagtailio/static/sass/components/_logos.scss
+++ b/wagtailio/static/sass/components/_logos.scss
@@ -1,5 +1,5 @@
 .logos {
-    @include sf-spacing();
+    @include sf-spacing(2);
     @include z-index(overlap); // so they sit above the large icons
     position: relative;
 

--- a/wagtailio/static/sass/components/_pagination.scss
+++ b/wagtailio/static/sass/components/_pagination.scss
@@ -1,5 +1,5 @@
 .pagination {
-    @include sf-spacing();
+    @include sf-spacing(2);
     grid-column: 2 / span 2;
     display: flex;
     flex-direction: column;

--- a/wagtailio/static/sass/components/_quotes.scss
+++ b/wagtailio/static/sass/components/_quotes.scss
@@ -1,5 +1,5 @@
 .quotes {
-    @include sf-spacing();
+    @include sf-spacing(2);
     position: relative;
     padding-top: 50px;
     overflow: hidden;

--- a/wagtailio/static/sass/components/_rich-text.scss
+++ b/wagtailio/static/sass/components/_rich-text.scss
@@ -40,7 +40,7 @@
     }
 
     &--sf {
-        @include sf-spacing();
+        @include sf-spacing(2);
         grid-column: 2 / span 2;
 
         @include media-query(medium) {

--- a/wagtailio/static/sass/components/_sign-up-form.scss
+++ b/wagtailio/static/sass/components/_sign-up-form.scss
@@ -1,6 +1,6 @@
 .sign-up-form {
     $root: &;
-    @include sf-spacing();
+    @include sf-spacing(2);
     grid-column: 2 / span 2;
 
     @include media-query(medium) {

--- a/wagtailio/static/sass/components/_standalone-quote.scss
+++ b/wagtailio/static/sass/components/_standalone-quote.scss
@@ -1,5 +1,5 @@
 .standalone-quote {
-    @include sf-spacing();
+    @include sf-spacing(2);
     align-items: center;
 
     &__icon {

--- a/wagtailio/static/sass/components/_text-media.scss
+++ b/wagtailio/static/sass/components/_text-media.scss
@@ -1,6 +1,6 @@
 .text-media {
     $root: &;
-    @include sf-spacing();
+    @include sf-spacing(2);
 
     &__content {
         margin: auto;

--- a/wagtailio/static/sass/layout/_blog-listing.scss
+++ b/wagtailio/static/sass/layout/_blog-listing.scss
@@ -1,5 +1,5 @@
 .blog-listing {
-    @include sf-spacing();
+    @include sf-spacing(2);
     grid-column: 2 / span 2;
     display: grid;
     grid-template-columns: 1fr;


### PR DESCRIPTION
The spacing between StreamField blocks was too large and making our blog pages look a little funny. I initially removed the media query in `@mixin sf-spacing()` but that broke the spacing around the hero areas and other elements. So I updated `sf-spacing` to include a variable `$multiple` that could be used to adjust spacing for individual elements in multiples of 25px. Then I updated all selectors that use that mixin according to the amount of space needed for each element.

I also removed a media-query the `.icon-bullet` selector since that needed adjustment as well.

Please let me know if there's anything I can do to improve this adjustment to the spacing.