### PR TITLE
Re-add text_and_media_block template

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/text_and_media_block/text_and_media_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/text_and_media_block/text_and_media_block.html
@@ -1,0 +1,30 @@
+{% load wagtailcore_tags wagtailimages_tags wagtailembeds_tags %}
+
+<div class="text-media {% if value.image_on_right or value.alignment == "right" %}text-media--right{% endif %} grid">
+
+    {% if value.image %}
+        {% image value.image fill-400x400 class="text-media__media" %}
+    {% else %}
+        <div class="text-media__embed-wrap responsive-object" style="padding-bottom: 56.25%">
+            {% embed value.embed.url %}
+        </div>
+    {% endif %}
+
+    <div class="text-media__content">
+        {% if value.heading %}
+            <h2>{{ value.heading }}</h2>
+        {% endif %}
+
+        {% if value.description  %}
+            <p>{{ value.description }}</p>
+        {% elif value.text %}
+            <div class="rich-text">
+                {{ value.text|richtext }}
+            </div>
+        {% endif %}
+
+        {% if value.cta %}
+            {% include "patterns/components/buttons/button.html" with url=value.cta.url title=value.cta.text arrow=True classes="text-media__button" %}
+        {% endif %}
+    </div>
+</div>

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/text_and_media_block/text_and_media_block.yaml
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/text_and_media_block/text_and_media_block.yaml
@@ -1,0 +1,15 @@
+context:
+  value:
+    image: True
+    image_on_right: False
+    heading: First 30 minutes of Wagtail
+    description: 'We want the initial experience with Wagtail to be the best it can be: a great demo experience, a smooth set-up process, easy onboarding, and great documentation.'
+    cta:
+      text: View docs
+      url: https://docs.wagtail.org/
+
+tags:
+  image:
+    value.image fill-400x400 class="text-media__media":
+      raw: |
+        <img src="https://placehold.co/400x400" class="text-media__media" alt="Some alt">


### PR DESCRIPTION
Still in use by `TextAndMediaBlock`. I searched for most of the removed templates in #382, but it looks like I missed this one