### PR TITLE
Updated Dockerfile to use AWS CLI v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,10 +77,10 @@ RUN apt-get install -y nodejs
 RUN curl https://cli-assets.heroku.com/install.sh | sh
 
 # Install AWS CLI
-RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip" && \
-    unzip /tmp/awscli-bundle.zip -d /tmp && \
-    /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    rm /tmp/awscli-bundle.zip && rm -r /tmp/awscli-bundle
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip ./aws
 
 # Switch to the application user
 USER wagtailio


### PR DESCRIPTION
The `make build` command was failing because it seems the AWS CLI file we were using is no longer available for download. I updated the commands in the Dockerfile to use AWS CLI version 2.

I tested the updated code with a fresh build in Docker on my local machine. I would appreciate someone else who has production access testing that this update works on their machine as well before merging this commit.