### PR TITLE
Prevent text being lost behind svg at tablet breakpoints

### DIFF
--- a/wagtailio/static/sass/components/_sign-up-form.scss
+++ b/wagtailio/static/sass/components/_sign-up-form.scss
@@ -19,9 +19,12 @@
 
     &__sub-heading {
         padding: 10px 0 0 0;
+        text-shadow: 2px 2px var(--color--background);
     }
 
     &__icon {
+        @include z-index(under);
+        position: relative;
         width: auto;
         height: 50px;
         margin-left: auto;


### PR DESCRIPTION
Before:
<img width="1026" alt="Screenshot 2023-08-03 at 09 18 31" src="https://github.com/wagtail/wagtail.org/assets/298766/6ea5d85d-659b-4485-866c-51d133fe9422">

After:
<img width="1035" alt="Screenshot 2023-08-03 at 09 18 43" src="https://github.com/wagtail/wagtail.org/assets/298766/76caeaa0-bce2-40f2-a5ab-e7c04b729f80">
