### PR TITLE
Minor fixes

### DIFF
--- a/wagtailio/static/sass/components/_logo-card.scss
+++ b/wagtailio/static/sass/components/_logo-card.scss
@@ -71,5 +71,9 @@
             padding: 10px 20px;
             background-color: $color--white;
         }
+
+        #{$root}__author-wrap #{$root}__image {
+            padding: 0;
+        }
     }
 }

--- a/wagtailio/static/sass/components/_sign-up-form.scss
+++ b/wagtailio/static/sass/components/_sign-up-form.scss
@@ -19,7 +19,6 @@
 
     &__sub-heading {
         padding: 10px 0 0 0;
-        text-shadow: 2px 2px var(--color--background);
     }
 
     &__icon {
@@ -104,6 +103,10 @@
 
         @include media-query(large) {
             padding: 60px;
+        }
+
+        #{$root}__sub-heading {
+            text-shadow: 2px 2px var(--color--background);
         }
     }
 


### PR DESCRIPTION
- Fixes #399 
- Fixes #400

![image](https://github.com/wagtail/wagtail.org/assets/6379424/97e1d9c2-25d3-4161-81e3-9789244bca48)

![image](https://github.com/wagtail/wagtail.org/assets/6379424/01e6d61f-4b9d-47c2-9510-d9ab929a5f4c)


<img width="478" alt="image" src="https://github.com/wagtail/wagtail.org/assets/6379424/2ffb2f1e-f2da-4bb8-9468-4a691062e44f">

<img width="478" alt="image" src="https://github.com/wagtail/wagtail.org/assets/6379424/a67eadcb-5183-4495-8041-811e99ce5969">

## Regression check

From what I tested, this doesn't seem to interfere with the CSS that was added that caused this bug.

The `text-shadow` added in #397 still works for its intended use case:
![image](https://github.com/wagtail/wagtail.org/assets/6379424/ea2c70c7-684a-4e0e-a612-f3c0762c326a)

The added padding for the `logo-card` image still works too:
<img width="486" alt="image" src="https://github.com/wagtail/wagtail.org/assets/6379424/7d6285e4-b872-4bf5-ab4e-416a21d307f6">
