### PR TITLE
Add featured label on featured blogs. Fix #351

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/includes/blog_post.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/includes/blog_post.html
@@ -21,6 +21,10 @@
                 {% include "patterns/components/icon/icon.html" with icon='arrow-alt' classes="blog-post__icon" %}
             {% endif %}
             <span>{{ post.date|date }}</span>
+            {% if featured %}
+                {% include "patterns/components/icon/icon.html" with icon='flame' classes="blog-post__icon" %}
+                <span>Featured</span>
+            {% endif %}
         </div>
 
         <h2 class="blog-post__title {% if featured %}heading-two{% endif %}">{{ post.title }}</h2>


### PR DESCRIPTION
Issue - #351 

Changes -
- Added featured label with icon on featured blog posts 

<img width="1468" alt="Screenshot 2023-10-14 at 1 22 06 AM" src="https://github.com/wagtail/wagtail.org/assets/61960532/42d41f5c-12d8-43a0-914c-45daa71793b9">

Let me know if I need to change the icon or do any other customizations.