### PR TITLE
Fixed disappearing text on hover for Sponsor This

### DIFF
--- a/wagtailio/static/sass/components/_milestone-item.scss
+++ b/wagtailio/static/sass/components/_milestone-item.scss
@@ -90,7 +90,7 @@
         }
 
         &:hover, &:focus-visible {
-            background-color: var(--color--interaction);
+            color: $color--teal-100;
             outline-offset: 4px;
         }
     }


### PR DESCRIPTION
Fixed Disappearing Text on Hover for 'Sponsor This' in Light Mode on the Wagtail Roadmap Page
Fixes:
1. Remove background color
2. Added color to the sponsor text on hover.

This is a PR for issue #428 

@thibaudcolas , could you kindly review it.