### PR TITLE
sass code fixes inside footer section: hover over SVG icons effect (Follow us icons)

### DIFF
--- a/wagtailio/static/sass/layout/_footer.scss
+++ b/wagtailio/static/sass/layout/_footer.scss
@@ -172,8 +172,8 @@
         transition: color 0.3s;
 
         &:hover {
-            color: $color--teal-100;
-            transition: color 0.3s;
+            fill: $color--teal-100;
+            transition: fill  $transition;
         }
 
     }


### PR DESCRIPTION
We can set color for SVG elements in two ways: using fill and stroke properties of the style attribute. Know more on [MDN docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill).


# hover over SVG icons effect on follow us links

![Untitled video - Made with Clipchamp](https://github.com/wagtail/wagtail.org/assets/91728992/ff655e6e-a7b9-44ff-a1f9-34fec5f68218)


This is a PR for issue [#440](https://github.com/wagtail/wagtail.org/issues/440)

@thibaudcolas  , I am outreachy applicant. could you kindly review it. I want to move on the other fixes.
