### PR TITLE
Install and enable image optimizer binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ ENV DJANGO_SETTINGS_MODULE=wagtailio.settings.production \
     WEB_CONCURRENCY=3
 
 # Install operating system dependencies.
-RUN apt-get update -y && \
-    apt-get install -y apt-transport-https rsync libmagickwand-dev unzip postgresql-client-13 && \
+RUN apt-get update --yes --quiet && \
+    apt-get install -y apt-transport-https rsync libmagickwand-dev unzip postgresql-client-13 \
+    jpegoptim pngquant gifsicle libjpeg-progs webp && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -503,6 +503,7 @@ LOGGING = {
 WAGTAIL_SITE_NAME = "wagtail.org"
 
 WAGTAILIMAGES_IMAGE_MODEL = "images.WagtailioImage"
+WILLOW_OPTIMIZERS = True
 
 if "PRIMARY_HOST" in env:
     WAGTAILADMIN_BASE_URL = "https://%s" % env["PRIMARY_HOST"]


### PR DESCRIPTION
This will help with rendition file sizes all across.

Example using the staging site homepage:
![before](https://github.com/wagtail/wagtail.org/assets/31622/50080001-59a3-491d-93e0-6c7a080c0710)
![after](https://github.com/wagtail/wagtail.org/assets/31622/7f2128d4-2c4d-4805-b53f-9e5a3470fdd5)

Dev note: after deployment, run `django-admin wagtail_update_image_renditions` on prod
