### PR TITLE
Fix TypeError in 500 error handling

### DIFF
--- a/wagtailio/utils/views.py
+++ b/wagtailio/utils/views.py
@@ -25,4 +25,6 @@ def error_404(request, exception=None):
 
 
 def error_500(request):
-    return defaults.server_error(request, template="patterns/pages/errors/500.html")
+    return defaults.server_error(
+        request, template_name="patterns/pages/errors/500.html"
+    )


### PR DESCRIPTION
Untested, just going by [the docs](https://docs.djangoproject.com/en/5.0/ref/views/#the-500-server-error-view). The exception:

```
File "/app/wagtailio/utils/views.py", line 28, in error_500
    return defaults.server_error(request, template="patterns/pages/errors/500.html")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[…]
TypeError: server_error() got an unexpected keyword argument 'template'
```