### PR TITLE
Update import path for promoted search Query model

### DIFF
--- a/wagtailio/search/views.py
+++ b/wagtailio/search/views.py
@@ -2,8 +2,8 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.template.response import TemplateResponse
 from django.utils.cache import add_never_cache_headers, patch_cache_control
 
+from wagtail.contrib.search_promotions.models import Query
 from wagtail.models import Page
-from wagtail.search.models import Query
 
 from wagtailio.utils.cache import get_default_cache_control_kwargs
 


### PR DESCRIPTION
Untested. See [5.0 release notes](https://docs.wagtail.org/en/stable/releases/5.0.html#wagtailsearch-query-has-moved-to-wagtail-contrib-search-promotions). Looking into this as part of a 500 error, but I have no idea if it’s enough:

```
File "/app/wagtailio/search/views.py", line 22, in search
    promoted_page_pks = query.editors_picks.all().values_list("page__pk", flat=True)
                        ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Query' object has no attribute 'editors_picks'
```