### PR TITLE
Headings and forms accessibility improvements

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/hero/hero.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/hero/hero.html
@@ -3,11 +3,11 @@
 <div class="grid">
     <div class="hero {% if classes %}{{ classes }}{% endif %}">
         <div class="hero__inner">
-            <hgroup role="group" aria-roledescription="heading group">
+            <hgroup>
                 <h1 class="hero__heading">{% firstof value.heading value.title %}</h1>
 
                 {% if value.sub_heading or value.subheading %}
-                    <p aria-roledescription="subheading" class="hero__subheading intro-big">{% firstof value.sub_heading value.subheading %}</p>
+                    <p class="hero__subheading intro-big">{% firstof value.sub_heading value.subheading %}</p>
                 {% endif %}
             </hgroup>
 

--- a/wagtailio/project_styleguide/templates/patterns/components/hero/hero.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/hero/hero.html
@@ -3,11 +3,13 @@
 <div class="grid">
     <div class="hero {% if classes %}{{ classes }}{% endif %}">
         <div class="hero__inner">
-            <h1 class="hero__heading">{% firstof value.heading value.title %}</h1>
+            <hgroup role="group" aria-roledescription="heading group">
+                <h1 class="hero__heading">{% firstof value.heading value.title %}</h1>
 
             {% if value.sub_heading or value.subheading %}
-                <h2 class="hero__subheading intro-big">{% firstof value.sub_heading value.subheading %}</h2>
+                <p aria-roledescription="subheading" class="hero__subheading intro-big">{% firstof value.sub_heading value.subheading %}</p>
             {% endif %}
+            </hgroup>
 
             {% if value.intro %}
                 <div class="hero__intro">{{ value.intro|richtext }}</div>

--- a/wagtailio/project_styleguide/templates/patterns/components/hero/hero.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/hero/hero.html
@@ -6,9 +6,9 @@
             <hgroup role="group" aria-roledescription="heading group">
                 <h1 class="hero__heading">{% firstof value.heading value.title %}</h1>
 
-            {% if value.sub_heading or value.subheading %}
-                <p aria-roledescription="subheading" class="hero__subheading intro-big">{% firstof value.sub_heading value.subheading %}</p>
-            {% endif %}
+                {% if value.sub_heading or value.subheading %}
+                    <p aria-roledescription="subheading" class="hero__subheading intro-big">{% firstof value.sub_heading value.subheading %}</p>
+                {% endif %}
             </hgroup>
 
             {% if value.intro %}

--- a/wagtailio/project_styleguide/templates/patterns/components/icon-link/icon-link.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/icon-link/icon-link.html
@@ -4,9 +4,11 @@
     {% include "patterns/components/icon/icon.html" with icon=value.icon classes="icon-link__svg" %}
 
     <div class="icon-link__content">
-        <h3 class="icon-link__heading teaser-heading">{{ value.heading }}</h3>
+        <hgroup role="group" aria-roledescription="heading group">
+            <h3 class="icon-link__heading teaser-heading">{{ value.heading }}</h3>
 
-        <h4 class="icon-link__subheading">{{ value.subheading }}</h4>
+            <p aria-roledescription="subheading" class="icon-link__subheading heading-four">{{ value.subheading }}</p>
+        </hgroup>
 
         <p class="icon-link__description mini-meta">{{ value.description }}</p>
     </div>

--- a/wagtailio/project_styleguide/templates/patterns/components/icon-link/icon-link.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/icon-link/icon-link.html
@@ -4,10 +4,10 @@
     {% include "patterns/components/icon/icon.html" with icon=value.icon classes="icon-link__svg" %}
 
     <div class="icon-link__content">
-        <hgroup role="group" aria-roledescription="heading group">
+        <hgroup>
             <h3 class="icon-link__heading teaser-heading">{{ value.heading }}</h3>
 
-            <p aria-roledescription="subheading" class="icon-link__subheading heading-four">{{ value.subheading }}</p>
+            <p class="icon-link__subheading heading-four">{{ value.subheading }}</p>
         </hgroup>
 
         <p class="icon-link__description mini-meta">{{ value.description }}</p>

--- a/wagtailio/project_styleguide/templates/patterns/components/sign_up_form/base_form.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/sign_up_form/base_form.html
@@ -3,7 +3,7 @@
     <p class="sign-up-form__sub-heading">{{ sub_heading }}</p>
     <form class="sign-up-form__container" action="https://torchbox.us1.list-manage.com/subscribe/post?u={{ mailchimp_account_id }}&id={{ mailchimp_newsletter_id }}" method="post">
         <div>
-            <label for="email" class="u-sr-only">Enter your email address</label>
+            <label for="email" class="u-sr-only">Email</label>
             <input class="sign-up-form__input" id="email" name="EMAIL" type="email" autocomplete="email" placeholder="Enter your email address" required/>
         </div>
         <button class="button sign-up-form__button" type="submit">

--- a/wagtailio/project_styleguide/templates/patterns/components/sign_up_form/base_form.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/sign_up_form/base_form.html
@@ -3,8 +3,7 @@
     <p class="sign-up-form__sub-heading">{{ sub_heading }}</p>
     <form class="sign-up-form__container" action="https://torchbox.us1.list-manage.com/subscribe/post?u={{ mailchimp_account_id }}&id={{ mailchimp_newsletter_id }}" method="post">
         <div>
-            <label for="email" class="u-sr-only">Email</label>
-            <input class="sign-up-form__input" id="email" name="EMAIL" type="email" autocomplete="email" placeholder="Enter your email address" required/>
+            <input class="sign-up-form__input" id="email" name="EMAIL" type="email" autocomplete="email" placeholder="Enter your email address" aria-label="Email" required/>
         </div>
         <button class="button sign-up-form__button" type="submit">
             <span class="button__text">Sign up</span>

--- a/wagtailio/project_styleguide/templates/patterns/components/sign_up_form/base_form.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/sign_up_form/base_form.html
@@ -1,16 +1,18 @@
 <div class="sign-up-form {% if classes %}{{ classes }}{% endif %}">
-    <h2 class="sign-up-form__heading heading-three">{{ heading }}</h2>
-    <p class="sign-up-form__sub-heading">{{ sub_heading }}</p>
-    <form class="sign-up-form__container" action="https://torchbox.us1.list-manage.com/subscribe/post?u={{ mailchimp_account_id }}&id={{ mailchimp_newsletter_id }}" method="post">
-        <div>
-            <input class="sign-up-form__input" id="email" name="EMAIL" type="email" autocomplete="email" placeholder="Enter your email address" aria-label="Email" required/>
-        </div>
-        <button class="button sign-up-form__button" type="submit">
-            <span class="button__text">Sign up</span>
-            <svg class="arrow" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
-        </button>
-        {% if icon %}
-            {% include "patterns/components/icon/icon.html" with classes="sign-up-form__icon" icon="" overlay_icon="wagtail-envelope"  %}
-        {% endif %}
-    </form>
+    <div class="sign-up-form__inner">
+        <h2 class="sign-up-form__heading heading-three">{{ heading }}</h2>
+        <p class="sign-up-form__sub-heading">{{ sub_heading }}</p>
+        <form class="sign-up-form__container" action="https://torchbox.us1.list-manage.com/subscribe/post?u={{ mailchimp_account_id }}&id={{ mailchimp_newsletter_id }}" method="post">
+            <div>
+                <input class="sign-up-form__input" id="email" name="EMAIL" type="email" autocomplete="email" placeholder="Enter your email address" aria-label="Email" required/>
+            </div>
+            <button class="button sign-up-form__button" type="submit">
+                <span class="button__text">Sign up</span>
+                <svg class="arrow" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
+            </button>
+        </form>
+    </div>
+    {% if icon %}
+        {% include "patterns/components/icon/icon.html" with classes="sign-up-form__icon" icon="" overlay_icon="wagtail-envelope"  %}
+    {% endif %}
 </div>

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/headline/headline.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/headline/headline.html
@@ -4,11 +4,11 @@
             {% include "patterns/components/icon/icon.html" with icon=value.icon classes="headline__icon" %}
         {% endif %}
         <div class="headline__inner">
-            <hgroup role="group" aria-roledescription="heading group">
+            <hgroup>
                 <h2 class="headline__heading heading-one">{{ value.heading }}</h2>
 
                 {% if value.sub_heading %}
-                    <p aria-roledescription="subheading" class="headline__subheading intro-big">{{ value.sub_heading }}</p>
+                    <p class="headline__subheading intro-big">{{ value.sub_heading }}</p>
                 {% endif %}
             </hgroup>
             {% if value.intro %}

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/headline/headline.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/headline/headline.html
@@ -3,25 +3,27 @@
         {% if value.icon %}
             {% include "patterns/components/icon/icon.html" with icon=value.icon classes="headline__icon" %}
         {% endif %}
+        <div class="headline__inner">
+            <hgroup role="group" aria-roledescription="heading group">
+                <h2 class="headline__heading heading-one">{{ value.heading }}</h2>
 
-        <h2 class="headline__heading heading-one">{{ value.heading }}</h2>
-
-        {% if value.sub_heading %}
-            <h3 class="headline__subheading intro-big">{{ value.sub_heading }}</h3>
-        {% endif %}
-
-        {% if value.intro %}
-            <p class="headline__intro">{{ value.intro }}</p>
-        {% endif %}
-
-        {% if value.cta %}
-            <div class="headline__button-wrap">
-                {% if value.dark_background or dark_background %}
-                    {% include "patterns/components/buttons/button.html" with arrow=True url=value.cta.url title=value.cta.text classes="headline__button button--dark" %}
-                {% else %}
-                    {% include "patterns/components/buttons/button.html" with arrow=True url=value.cta.url title=value.cta.text classes="headline__button" %}
+                {% if value.sub_heading %}
+                    <p aria-roledescription="subheading" class="headline__subheading intro-big">{{ value.sub_heading }}</p>
                 {% endif %}
-            </div>
-        {% endif %}
+            </hgroup>
+            {% if value.intro %}
+                <p class="headline__intro">{{ value.intro }}</p>
+            {% endif %}
+
+            {% if value.cta %}
+                <div class="headline__button-wrap">
+                    {% if value.dark_background or dark_background %}
+                        {% include "patterns/components/buttons/button.html" with arrow=True url=value.cta.url title=value.cta.text classes="headline__button button--dark" %}
+                    {% else %}
+                        {% include "patterns/components/buttons/button.html" with arrow=True url=value.cta.url title=value.cta.text classes="headline__button" %}
+                    {% endif %}
+                </div>
+            {% endif %}
+        </div>
     </div>
 </div>

--- a/wagtailio/project_styleguide/templates/patterns/includes/menu_get_started.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/menu_get_started.html
@@ -14,7 +14,7 @@
                         </header>
                         <main class="modal__content">
                             {% if get_started.heading %}
-                                <p class="modal__title intro-small" id="get-started-menu-title">{{ get_started.heading }}</p>
+                                <h2 class="modal__title intro-small" id="get-started-menu-title">{{ get_started.heading }}</h2>
                             {% endif %}
 
                             <ul class="modal__grid modal__grid--get-started">

--- a/wagtailio/project_styleguide/templates/patterns/includes/search-form.html
+++ b/wagtailio/project_styleguide/templates/patterns/includes/search-form.html
@@ -1,10 +1,10 @@
 <form action="{% url 'search' %}" method="get" role="search" class="search {% if classes %}{{ classes }}{% endif %}" {% if data_attrs %}{{ data_attrs }}{% endif %} {% if form_id %}id="{{ form_id }}"{% endif %}>
-    <fieldset class="search__wrap">
+    <div class="search__wrap">
         <label class="u-sr-only" for="{{ input_id }}">Enter a search term</label>
         <input class="search__input" id="{{ input_id }}" type="search" name="query"{% if search_query %} value="{{ search_query }}"{% endif %} placeholder="Search...">
         <button type="submit" class="button button--secondary button--form search__button" aria-label="Search the site content">
             <span class="button__text">Search</span>
             <svg class="arrow" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
         </button>
-    </fieldset>
+    </div>
 </form>

--- a/wagtailio/static/sass/base/_typography.scss
+++ b/wagtailio/static/sass/base/_typography.scss
@@ -79,7 +79,8 @@ h4,
 .intro-small {
     font-size: 1.25rem;
     line-height: 1.9375rem;
-
+    font-weight: $weight--regular;
+    
     @include media-query(large) {
         font-size: 1.25rem;
         line-height: 1.85rem;
@@ -111,6 +112,7 @@ h4,
     font-size: 1.5625rem;
     line-height: 2.3125rem;
     font-weight: $weight--regular;
+    margin: 0 0 20px;
 
     @include media-query(large) {
         font-size: 2rem;

--- a/wagtailio/static/sass/components/_headline.scss
+++ b/wagtailio/static/sass/components/_headline.scss
@@ -20,30 +20,29 @@
         position: relative;
     }
 
-    &__heading {
+    &__inner {
         @include z-index(overlap);
-        position: relative;
         grid-column: 2 / span 2;
-
+      
         @include media-query(medium) {
             grid-column: 2 / span 3;
         }
 
         @include media-query(large) {
             grid-column: 2 / span 3;
+        }
+    }
+
+    &__heading {
+        
+        @include media-query(large) {
             width: 120%; // to get a bit of overlap on the icon
             padding-top: $gutter-lg;
         }
     }
 
     &__subheading {
-        position: relative;
         margin-bottom: 20px;
-        grid-column: 2 / span 2;
-
-        @include media-query(medium) {
-            grid-column: 2 / span 3;
-        }
     }
 
     &__intro {
@@ -51,22 +50,12 @@
         grid-column: 2 / span 2;
 
         @include media-query(medium) {
-            grid-column: 2 / span 3;
             margin-bottom: 40px;
-        }
-
-        @include media-query(large) {
-            grid-column: 2 / span 3;
         }
     }
 
     &__button-wrap {
         margin: 0;
-        grid-column: 2 / span 2;
-
-        @include media-query(medium) {
-            grid-column: 2 / span 3;
-        }
 
         @include media-query(large) {
             grid-column: 2 / span 2;

--- a/wagtailio/static/sass/components/_search.scss
+++ b/wagtailio/static/sass/components/_search.scss
@@ -10,6 +10,8 @@
         border-top-left-radius: 0;
         padding: 10px;
 
+        @include focus-internal();
+
         @include media-query(medium) {
             padding: 15px 30px;
         }
@@ -32,6 +34,8 @@
         color: var(--color--text);
         height: 100%;
         background-color: var(--color--light-dark);
+        
+        @include focus-internal();
 
         // remove rounded edges in ios
         &[type="search"] {

--- a/wagtailio/static/sass/components/_sign-up-form.scss
+++ b/wagtailio/static/sass/components/_sign-up-form.scss
@@ -3,7 +3,7 @@
     @include sf-spacing(2);
     grid-column: 2 / span 2;
     overflow: hidden; // prevent scrollbars from svg size
-
+    
     @include media-query(medium) {
       grid-column: 2 / span 3;
     }
@@ -25,28 +25,32 @@
         @include z-index(under);
         position: relative;
         width: auto;
-        margin-left: auto;
-        display: none;
 
         @include media-query(medium) {
             display: block;
-            height: 50px;
+        }
+        
+        @include media-query(large) {
+            flex-grow: 1.5;
         }
 
         > svg {
             position: relative;
             width: 170px;
             height: 170px;
+        }
+    }
 
-            @include media-query(medium) {
-                inset: -100px 0 auto auto;
-            }
+    &__inner {
+        @include media-query(large) {
+            flex-grow: 1.5;
         }
     }
 
     &__container {
         display: flex;
         flex-direction: column;
+        margin: 30px 0 0 0;
 
         @include media-query(medium) {
             flex-direction: row;
@@ -82,10 +86,6 @@
         }
     }
 
-    > form {
-        margin: 30px 0 0 0;
-    }
-
     &__button {
         border-radius: $rounded-md;
         border-style: solid;
@@ -105,16 +105,18 @@
     }
 
     &--block {
+        display: flex;
+        flex-direction: column;
         border: 1px solid var(--color--text);
         border-radius: 15px;
         padding: 30px;
 
-        @include media-query(large) {
-            padding: 60px;
+        @include media-query(medium) {
+            flex-direction: row;
         }
 
-        #{$root}__sub-heading {
-            text-shadow: 2px 2px var(--color--background);
+        @include media-query(large) {
+            padding: 40px 60px;
         }
     }
 

--- a/wagtailio/static/sass/components/_sign-up-form.scss
+++ b/wagtailio/static/sass/components/_sign-up-form.scss
@@ -25,19 +25,22 @@
         @include z-index(under);
         position: relative;
         width: auto;
-        height: 50px;
         margin-left: auto;
         display: none;
 
-        @include media-query(large) {
+        @include media-query(medium) {
             display: block;
+            height: 50px;
         }
 
         > svg {
             position: relative;
-            inset: -100px 0 auto auto;
             width: 170px;
             height: 170px;
+
+            @include media-query(medium) {
+                inset: -100px 0 auto auto;
+            }
         }
     }
 
@@ -55,6 +58,7 @@
             margin: 0;
 
             @include media-query(medium) {
+                flex: 1;
                 width: 50%;
             }
         }
@@ -118,12 +122,6 @@
         background-color: var(--color--highlight);
         color: $color--white;
 
-        #{$root}__container > div {
-            @include media-query(medium) {
-                flex: 1;
-            }
-        }
-
         #{$root}__input {
             background-color: var(--color--highlight);
             border: 1px solid $color--white;
@@ -157,7 +155,6 @@
     }
 
     .footer & {
-
       @include media-query(large) {
         margin-bottom: 50px;
       }
@@ -172,6 +169,5 @@
       &__container {
         margin-top: 0;
       }
-
     }
 }


### PR DESCRIPTION
This PR addresses accessibility issues related to heading levels and forms:

- Fixed instances (in hero, headline, and icon-link blocks) where headings were used consecutively after one another.
- Changed menu_get_started to use an `h2`
- #457
- #459
- Currently screen reader announces sign up forms on the site with "Enter your email address" repeated 3 times. Fixed by changing base_form to use `aria-label="Email"` instead of `<label>`
- Changes the use of `fieldset` in search-form to a `div` (fieldset is used to group multiple form fields together, but there's only one here)

<details>
  <summary>Screenshots</summary>

  | before | after |
  | --- | --- |
  |![Screenshot (109)](https://github.com/wagtail/wagtail.org/assets/106587342/fc15bf10-9c86-4492-b8e9-8be0b6bdd35c)|![Screenshot (105)](https://github.com/wagtail/wagtail.org/assets/106587342/76857a70-8971-4364-83f0-186e50071d49)|
![Screenshot (110)](https://github.com/wagtail/wagtail.org/assets/106587342/049f521b-a199-4f15-8084-06c4157334e0)|![Screenshot (106)](https://github.com/wagtail/wagtail.org/assets/106587342/10d14cef-ff53-402a-bcc0-52f204713c5b)|

</details>

