### PR TITLE
Print stylesheets and WHCM improvements

### DIFF
--- a/wagtailio/static/sass/base/_print.scss
+++ b/wagtailio/static/sass/base/_print.scss
@@ -1,0 +1,87 @@
+// Print styles
+// stylelint-disable declaration-no-important
+
+@media print {
+    * {
+        background: transparent !important;
+        color: $color--black !important;
+        border-color: $color--black !important;
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+
+    .header, .hero {
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    a,
+    a:visited {
+        text-decoration: underline;
+    }
+
+    a[href^='http']::after {
+        content: ' (' attr(href) ')'; // Display link URL
+    }
+
+    abbr[title]::after {
+        content: " (" attr(title) ")";
+    }
+
+    a[href^="#"]::after,
+    a[href^="javascript:"]::after {
+        content: "";
+    }
+
+    p a {
+        word-wrap: break-word;
+    }
+
+    pre {
+        white-space: pre-wrap !important;
+    }
+
+    thead {
+        display: table-header-group;
+    }
+
+    tr,
+    img {
+        page-break-inside: avoid;
+    }
+
+    img {
+        width: 50%;  // Prevent images from spanning the entire page
+    }
+
+    p,
+    h2,
+    h3 {
+        orphans: 3;
+        widows: 3;
+    }
+
+    // Hide integrated videos and remove whitespace
+    iframe, video {
+        display: none;
+        width: 0 !important;
+        height: 0 !important;
+        overflow: hidden !important;
+        line-height: 0pt !important;
+        white-space: nowrap;
+    }
+
+    .embed, .home-embed {
+        position: absolute;
+        height: 0;
+        overflow: hidden;
+    }
+
+    // Hide interactive elements
+    header .header__actions, footer,
+    .cookie .cookie__container,
+    .related-content.grid,
+    .sign-up-form, .hero__icon, .headline__icon{
+        display: none;
+    }
+}

--- a/wagtailio/static/sass/components/_burger.scss
+++ b/wagtailio/static/sass/components/_burger.scss
@@ -12,6 +12,10 @@
     &:focus {
         #{$root}__line {
             background-color: var(--color--interaction);
+
+            @media (forced-colors: active) {
+                background-color: ButtonText;
+            }
         }
     }
 
@@ -27,6 +31,10 @@
         transform: translateX(-50%) rotate(0deg);
         transition: top $transition, width $transition, opacity $transition, transform $transition, background-color $transition, left $transition;
 
+        @media (forced-colors: active) {
+            background-color: ButtonText;
+        }
+        
         .is-open & {
             width: 27px;
             height: 4px;

--- a/wagtailio/static/sass/components/_buttons.scss
+++ b/wagtailio/static/sass/components/_buttons.scss
@@ -18,6 +18,10 @@
         transition: transform 0.3s;
         margin: 0 0 0 15px;
         fill: $color--teal;
+
+        @media (forced-colors: active) {
+            fill: currentColor;
+        }
     }
 
     &:hover {
@@ -27,6 +31,10 @@
         > svg {
             transform: translateX(6px) scale(1.05);
             fill: $color--teal-100;
+
+            @media (forced-colors: active) {
+                fill: currentColor;
+            }
         }
     }
 
@@ -38,6 +46,10 @@
 
         > svg {
             fill: $color--teal-100;
+
+            @media (forced-colors: active) {
+                fill: currentColor;
+            }
         }
 
         &:hover,
@@ -48,6 +60,11 @@
 
             > svg {
                 fill: $color--teal;
+
+                // stylelint-disable-next-line max-nesting-depth
+                @media (forced-colors: active) {
+                    fill: currentColor;
+                }
             }
         }
     }
@@ -103,6 +120,4 @@
         font-weight: $weight--bold;
         line-height: 1.25rem;
     }
-
-
 }

--- a/wagtailio/static/sass/components/_code-snippet.scss
+++ b/wagtailio/static/sass/components/_code-snippet.scss
@@ -36,22 +36,24 @@
         width: 20px;
         height: 20px;
         transition: color 0.3s;
-    }
 
-    &__button {
-        padding: 0;
-
-        &:focus {
-            outline-color: var(--color--heading);
+        @media (forced-colors: active) {
+            fill: currentColor;
         }
 
         &:hover,
         &:active,
         &:focus {
-            #{$root}__icon {
                 fill: $color--white;
-            }
+
+                @media (forced-colors: active) {
+                    fill: currentColor;
+                }
         }
+    }
+
+    &__button {
+        padding: 0;
     }
 
     &__confirmation {

--- a/wagtailio/static/sass/components/_modal.scss
+++ b/wagtailio/static/sass/components/_modal.scss
@@ -42,11 +42,15 @@
             width: 30px;
             height: 30px;
             border: 3px solid $color--white;
+        }
 
-            svg {
-                fill: $color--white;
-                width: 12px;
-                height: 22px;
+        #{$root}__close-icon {
+            fill: $color--white;
+            width: 12px;
+            height: 22px;
+
+            @media (forced-colors: active) {
+                fill: currentColor;
             }
         }
     }
@@ -113,10 +117,12 @@
             }
         }
 
-        &:hover,
-        &:focus {
-            #{$root}__close-icon {
-                fill: var(--color--interaction);
+        .theme-dark & {
+            &:hover,
+            &:focus {
+                #{$root}__close-icon {
+                    fill: $color--teal-100;
+                }
             }
         }
     }

--- a/wagtailio/static/sass/components/_theme-toggle.scss
+++ b/wagtailio/static/sass/components/_theme-toggle.scss
@@ -117,8 +117,4 @@
     .no-js & {
         display: none;
     }
-
-    @media print {
-        display: none;
-     }
 }

--- a/wagtailio/static/sass/main.scss
+++ b/wagtailio/static/sass/main.scss
@@ -11,6 +11,7 @@
 @import 'base/base';
 @import 'base/container';
 @import 'base/typography';
+@import 'base/print';
 
 // Components
 @import 'components/app';


### PR DESCRIPTION
This PR addresses styling issues related to print stylesheets and windows high contrast mode:

**Print stylesheets**
- Components with dark backgrounds arent rendered correctly in print. The text appears gray instead of black. 
- Interactive content such as header navigation elements (search, menu toggle), sign-up forms, and videos should be hidden for print.
- In-line href attributes should be used in print so that users are aware of destination of each link.
- Only important iconography and images should be retained for print.

Most site visitors would likely want to print or save blog posts as PDFs compared to other pages on the site. You can see the difference between the blog post [without print styles](https://drive.google.com/file/d/1cRyr8Z1enN4A5GoXRThyD6grKTP-qkJn/view?usp=sharing) and the one [with print styles](https://drive.google.com/file/d/1fkyhDPLI0zRV_CkOufKTx_ToRqYluiVJ/view?usp=sharing).

**WHCM** #454
- Menu toggle isn't visible
- Close icon in the search modal isn’t visible
- Copy icon in "pip install Wagtail" button disappears when clicking on it.
- (not in audit) SVG icons in buttons now match the button text color

<details>
  <summary>Screenshots</summary>

  ||forced-colors: active + prefers-color-scheme: dark|forced-colors: active + prefers-color-scheme: light|
  | --- | --- | --- |
  |![Screenshot (91)](https://github.com/wagtail/wagtail.org/assets/106587342/e885b0a5-08ad-433a-ab43-09dcd7848580)|![Screenshot (90)](https://github.com/wagtail/wagtail.org/assets/106587342/30b8c805-99f8-4c8f-8051-da7b461540e2)|![Screenshot (89)](https://github.com/wagtail/wagtail.org/assets/106587342/d0dd442a-d424-48f5-8d5f-9635fd8ef470)|
![Screenshot (95)](https://github.com/wagtail/wagtail.org/assets/106587342/b09bb6e2-9760-499d-bcb2-1b3da6482d28)|![Screenshot (93)](https://github.com/wagtail/wagtail.org/assets/106587342/9fdda237-7a72-4991-9360-fdcc1e498c08)|![Screenshot (92)](https://github.com/wagtail/wagtail.org/assets/106587342/b199d372-f5c7-4e75-936f-8ce9e1d19231)
![Screenshot (96)](https://github.com/wagtail/wagtail.org/assets/106587342/986d2c22-98b7-4d6d-9cbc-674aede6eac8)|![Screenshot (98)](https://github.com/wagtail/wagtail.org/assets/106587342/2ca270f0-596f-4ded-a109-43ae4857afab)|![Screenshot (97)](https://github.com/wagtail/wagtail.org/assets/106587342/b1491690-8646-4460-8ded-bde713684e28)

</details>