### PR TITLE
Updating the image settings to allow avif and webp image formats.

### DIFF
--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -497,12 +497,12 @@ WAGTAIL_SITE_NAME = "wagtail.org"
 
 WAGTAILIMAGES_IMAGE_MODEL = "images.WagtailioImage"
 
-WAGTAILIMAGES_EXTENSIONS = ['avif', 'jpg', 'png', 'webp']
+WAGTAILIMAGES_EXTENSIONS = ["avif", "jpg", "png", "webp"]
 
 WAGTAILIMAGES_FORMAT_CONVERSIONS = {
-        'avif': 'avif',
-        'webp': 'webp',
-    }
+    "avif": "avif",
+    "webp": "webp",
+}
 
 WILLOW_OPTIMIZERS = True
 

--- a/wagtailio/settings/base.py
+++ b/wagtailio/settings/base.py
@@ -496,6 +496,14 @@ LOGGING = {
 WAGTAIL_SITE_NAME = "wagtail.org"
 
 WAGTAILIMAGES_IMAGE_MODEL = "images.WagtailioImage"
+
+WAGTAILIMAGES_EXTENSIONS = ['avif', 'jpg', 'png', 'webp']
+
+WAGTAILIMAGES_FORMAT_CONVERSIONS = {
+        'avif': 'avif',
+        'webp': 'webp',
+    }
+
 WILLOW_OPTIMIZERS = True
 
 if "PRIMARY_HOST" in env:


### PR DESCRIPTION
Due to the default Wagtail behavior of converting avif and webp files to PNGs, we need these settings to allow for these newer and greener file formats to be used on Wagtail.org.

I have decided that will not support GIFs as they tend to be large, unwieldy files and they are a potential source of chaos if animated versions are allowed to be uploaded.