### PR TITLE
Apply richtext styles to markdown blocks and improve spacing of markdown/code blocks

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/code_block/code_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/code_block/code_block.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 <div class="grid">
-    <div class="grid-align">
+    <div class="code-block">
         {{ code }}
     </div>
 </div>

--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/code_block/code_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/code_block/code_block.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 <div class="grid">
-    <div class="code-block">
+    <div class="code-block code-block--{{ self.block.name|default:'markdownblock' }}">
         {{ code }}
     </div>
 </div>

--- a/wagtailio/static/sass/abstracts/_mixins.scss
+++ b/wagtailio/static/sass/abstracts/_mixins.scss
@@ -110,3 +110,46 @@
 @mixin z-index($key) {
     z-index: z-index($key);
 }
+
+// Apply formatting for elements using richtext 
+@mixin richtext() {
+    a {
+        color: var(--color--link);
+        transition: color 0.3s;
+
+        &:hover {
+            color: var(--color--interaction);
+        }
+    }
+
+    b {
+        font-weight: $weight--bold;
+    }
+
+    ul,
+    ol {
+        list-style: outside;
+        padding-left: 20px;
+        margin-bottom: 20px;
+
+        @include media-query(medium) {
+            margin-bottom: 40px;
+        }
+    }
+
+    ol {
+        list-style: roman;
+    }
+
+    p {
+        margin: 0 0 20px;
+
+        @include media-query(large) {
+            margin: 0 0 40px;
+        }
+
+        &:last-child {
+            margin: 0;
+        }
+    }
+}

--- a/wagtailio/static/sass/components/_code-block.scss
+++ b/wagtailio/static/sass/components/_code-block.scss
@@ -1,5 +1,4 @@
 .code-block {
-    @include richtext();
     @include sf-spacing(2);
     
     grid-column: 2 / span 2;
@@ -12,8 +11,11 @@
         grid-column: 3 / span 3;
     }
 
-    // Make `CodeBlock` and code blocks within `MarkDownBlock` look the same.
     &--markdownblock {
+        // Ensure HTML components are styled correctly.
+        @include richtext();
+        
+        // Make `CodeBlock` and code blocks within `MarkDownBlock` look the same.
         pre {
             @include sf-spacing(2);
         }

--- a/wagtailio/static/sass/components/_code-block.scss
+++ b/wagtailio/static/sass/components/_code-block.scss
@@ -1,5 +1,6 @@
 .code-block {
     @include richtext();
+    @include sf-spacing(2);
     
     grid-column: 2 / span 2;
 
@@ -9,5 +10,12 @@
 
     @include media-query(large) {
         grid-column: 3 / span 3;
+    }
+
+    // Make `CodeBlock` and code blocks within `MarkDownBlock` look the same.
+    &--markdownblock {
+        pre {
+            @include sf-spacing(2);
+        }
     }
 }

--- a/wagtailio/static/sass/components/_code-block.scss
+++ b/wagtailio/static/sass/components/_code-block.scss
@@ -1,4 +1,6 @@
-.grid-align {
+.code-block {
+    @include richtext();
+    
     grid-column: 2 / span 2;
 
     @include media-query(medium) {

--- a/wagtailio/static/sass/components/_rich-text.scss
+++ b/wagtailio/static/sass/components/_rich-text.scss
@@ -1,43 +1,5 @@
 .rich-text {
-    a {
-        color: var(--color--link);
-        transition: color 0.3s;
-
-        &:hover {
-            color: var(--color--interaction);
-        }
-    }
-
-    b {
-        font-weight: $weight--bold;
-    }
-
-    ul,
-    ol {
-        list-style: outside;
-        padding-left: 20px;
-        margin-bottom: 20px;
-
-        @include media-query(medium) {
-            margin-bottom: 40px;
-        }
-    }
-
-    ol {
-        list-style: roman;
-    }
-
-    p {
-        margin: 0 0 20px;
-
-        @include media-query(large) {
-            margin: 0 0 40px;
-        }
-
-        &:last-child {
-            margin: 0;
-        }
-    }
+    @include richtext();
 
     &--sf {
         @include sf-spacing(2);

--- a/wagtailio/static/sass/main.scss
+++ b/wagtailio/static/sass/main.scss
@@ -28,6 +28,7 @@
 @import 'components/code-snippet';
 @import 'components/comparison-table';
 @import 'components/cookie-message';
+@import 'components/code-block';
 @import 'components/cta';
 @import 'components/cta-block';
 @import 'components/document';
@@ -39,7 +40,6 @@
 @import 'components/footer-menu';
 @import 'components/get-started';
 @import 'components/grid';
-@import 'components/grid-align';
 @import 'components/heading';
 @import 'components/headline';
 @import 'components/hero';

--- a/wagtailio/static/sass/vendor/_code-highlighting.scss
+++ b/wagtailio/static/sass/vendor/_code-highlighting.scss
@@ -3,6 +3,7 @@
     white-space: pre-wrap;
     padding: 1em;
     font-size: 0.85em;
+    margin: 0;
 
     @media (forced-colors: active) {
         border: 1px solid;


### PR DESCRIPTION
This MR will:

1. Apply the same rich text styles applied to `RichTextBlock` to `MarkDownBlock`, which fixes display issues of `ul` and makes other elements display consistently within `MarkDownBlock`s.
2. Standardise the spacing of code blocks within `MarkDownBlock` and `CodeBlock`

### Screenshots

Both "Before" and "After" screenshots below are taken using the same StreamField which uses two approaches to achieve the same content:

![Streamfield](https://github.com/wagtail/wagtail.org/assets/3009233/c32363b2-4371-4177-9216-180b75e2c072)

#### Before
![Before](https://github.com/wagtail/wagtail.org/assets/3009233/706a8673-bac8-43f1-a450-b912932996e4)

#### After
![After](https://github.com/wagtail/wagtail.org/assets/3009233/20291b2c-5936-4c7c-8b1e-fecccb18bb77)
