### PR TITLE
Remove surplus margin from richtext elements

### DIFF
--- a/wagtailio/static/sass/abstracts/_mixins.scss
+++ b/wagtailio/static/sass/abstracts/_mixins.scss
@@ -147,10 +147,6 @@
         @include media-query(large) {
             margin: 0 0 40px;
         }
-
-        &:last-child {
-            margin: 0;
-        }
     }
 
     // Remove whatever margin is on the last child as we rely on the parent

--- a/wagtailio/static/sass/abstracts/_mixins.scss
+++ b/wagtailio/static/sass/abstracts/_mixins.scss
@@ -152,4 +152,10 @@
             margin: 0;
         }
     }
+
+    // Remove whatever margin is on the last child as we rely on the parent
+    // container's margin (i.e. the block itself).
+    > :last-child {
+        margin-bottom: 0;
+    }
 }


### PR DESCRIPTION
This MR removes the bottom margin from the last element (`:last-child`) of rich text elements so that we rely on the parent block's spacing rather than that _plus_ whatever margin exists on the last element.

The example below removes the bottom margin from the `ul`.

**Before:**

![Before](https://github.com/wagtail/wagtail.org/assets/3009233/76ffdcb5-39ff-4b77-b6d6-67ae04fd0541)

**After:**

![After](https://github.com/wagtail/wagtail.org/assets/3009233/eacc7ce9-c4fc-4375-bad8-568d54801804)
