### PR TITLE
Added an image usage report

### DIFF
--- a/wagtailio/images/views.py
+++ b/wagtailio/images/views.py
@@ -1,5 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import CharField, Count, IntegerField, OuterRef, Subquery
+from django.db.models import CharField, Count, OuterRef, Subquery
 from django.db.models.functions import Cast, Coalesce
 from django.utils.translation import gettext_lazy as _
 
@@ -39,8 +39,11 @@ class ImageUsageReport(ReportView):
                 # to_object_id is a varchar so we need to cast the image PK to a varchar for comparison
                 to_object_id=Cast(OuterRef("pk"), output_field=CharField()),
             )
-            .values(cast_to_object_id=Cast("to_object_id", output_field=IntegerField()))
-            .values(count=Count("id"))
+            .values("object_id", "to_object_id")
+            .distinct()
+            .values("to_object_id")
+            .annotate(count=Count("object_id", distinct=True))
+            .values("count")
         )
 
         return WagtailIOImage.objects.annotate(

--- a/wagtailio/images/views.py
+++ b/wagtailio/images/views.py
@@ -3,11 +3,58 @@ from django.db.models import CharField, Count, OuterRef, Subquery
 from django.db.models.functions import Cast, Coalesce
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.filters import CollectionFilter, WagtailFilterSet
 from wagtail.admin.ui.tables import TitleColumn
 from wagtail.admin.views.reports import ReportView
-from wagtail.models import ReferenceIndex
+from wagtail.models import Collection, ReferenceIndex
+
+from django_filters import ChoiceFilter as DjangoChoiceFilter
 
 from .models import WagtailIOImage
+
+
+class UsageFilter(DjangoChoiceFilter):
+    def filter(self, qs, value):
+        # Value passed will be one of the choices
+        if value:
+            if value in ["0", "1"]:
+                return qs.filter(usage_count=value)
+            else:
+                # If the value is not 0 or 1, we can assume means greater than 1
+                return qs.filter(usage_count__gt=1)
+        # If the value is not in the choices, return the original queryset
+        return qs
+
+
+class ImageUsageReportFilterSet(WagtailFilterSet):
+    collection = CollectionFilter(
+        label=_("Collection"),
+        help_text=_("Filter images by their collection."),
+    )
+    usage = UsageFilter(
+        label=_("Usage"),
+        help_text=_("Filter images by their usage count."),
+        choices=[
+            (0, _("Not used")),
+            (1, _("Used once")),
+            (2, _("Used more than once")),
+        ],
+    )
+
+    class Meta:
+        model = WagtailIOImage
+        fields = ["collection", "usage"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.collections = {
+            collection.pk: collection for collection in Collection.objects.all()
+        }
+        self.collections_filter_enabled = True
+        if len(self.collections) == 1:
+            # If there is only one collection, we don't need to show the collection filter
+            self.collections_filter_enabled = False
+            del self.filters["collection"]
 
 
 class ImageUsageReport(ReportView):
@@ -15,6 +62,7 @@ class ImageUsageReport(ReportView):
     header_icon = "image"
     index_url_name = "image_usage_report"
     index_results_url_name = "image_usage_report_results"
+    filterset_class = ImageUsageReportFilterSet
     default_ordering = "-usage_count"
     columns = [
         TitleColumn(

--- a/wagtailio/images/views.py
+++ b/wagtailio/images/views.py
@@ -30,6 +30,11 @@ class ImageUsageReport(ReportView):
             sort_key="usage_count",
         ),
     ]
+    list_export = ["title", "description", "usage_count", "created_at"]
+    export_headings = {
+        "usage_count": _("Times Used"),
+    }
+    export_filename = "image_usage_report"
 
     def get_base_queryset(self):
         # Create the subquery to count matching ReferenceIndex rows

--- a/wagtailio/images/views.py
+++ b/wagtailio/images/views.py
@@ -1,6 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import CharField, Count, IntegerField, OuterRef, Subquery
-from django.db.models.functions import Cast
+from django.db.models.functions import Cast, Coalesce
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.ui.tables import TitleColumn
@@ -44,5 +44,5 @@ class ImageUsageReport(ReportView):
         )
 
         return WagtailIOImage.objects.annotate(
-            usage_count=Subquery(reference_index_subquery)
+            usage_count=Coalesce(Subquery(reference_index_subquery.values("count")), 0)
         )

--- a/wagtailio/images/views.py
+++ b/wagtailio/images/views.py
@@ -1,0 +1,48 @@
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import CharField, Count, IntegerField, OuterRef, Subquery
+from django.db.models.functions import Cast
+from django.utils.translation import gettext_lazy as _
+
+from wagtail.admin.ui.tables import TitleColumn
+from wagtail.admin.views.reports import ReportView
+from wagtail.models import ReferenceIndex
+
+from .models import WagtailIOImage
+
+
+class ImageUsageReport(ReportView):
+    page_title = "Image usage report"
+    header_icon = "image"
+    index_url_name = "image_usage_report"
+    index_results_url_name = "image_usage_report_results"
+    default_ordering = "-usage_count"
+    columns = [
+        TitleColumn(
+            "title",
+            label=_("Image Title"),
+            url_name="wagtailimages:edit",
+            sort_key="title",
+        ),
+        TitleColumn(
+            "usage_count",
+            label=_("Times Used"),
+            url_name="wagtailimages:image_usage",
+            sort_key="usage_count",
+        ),
+    ]
+
+    def get_base_queryset(self):
+        # Create the subquery to count matching ReferenceIndex rows
+        reference_index_subquery = (
+            ReferenceIndex.objects.filter(
+                to_content_type=ContentType.objects.get_for_model(WagtailIOImage),
+                # to_object_id is a varchar so we need to cast the image PK to a varchar for comparison
+                to_object_id=Cast(OuterRef("pk"), output_field=CharField()),
+            )
+            .values(cast_to_object_id=Cast("to_object_id", output_field=IntegerField()))
+            .values(count=Count("id"))
+        )
+
+        return WagtailIOImage.objects.annotate(
+            usage_count=Subquery(reference_index_subquery)
+        )

--- a/wagtailio/images/wagtail_hooks.py
+++ b/wagtailio/images/wagtail_hooks.py
@@ -1,0 +1,33 @@
+from django.urls import path, reverse
+
+from wagtail import hooks
+from wagtail.admin.menu import AdminOnlyMenuItem
+
+from .views import ImageUsageReport
+
+
+@hooks.register("register_reports_menu_item")
+def register_image_usage_report_menu_item():
+    return AdminOnlyMenuItem(
+        "Image usage report",
+        reverse("image_usage_report"),
+        icon_name=ImageUsageReport.header_icon,
+        order=700,
+    )
+
+
+@hooks.register("register_admin_urls")
+def register_image_usage_report_url():
+    return [
+        path(
+            "reports/image_usage_report/",
+            ImageUsageReport.as_view(),
+            name="image_usage_report",
+        ),
+        # Add a results-only view to add support for AJAX-based filtering
+        path(
+            "reports/image_usage_report/results/",
+            ImageUsageReport.as_view(results_only=True),
+            name="image_usage_report_results",
+        ),
+    ]

--- a/wagtailio/images/wagtail_hooks.py
+++ b/wagtailio/images/wagtail_hooks.py
@@ -12,7 +12,7 @@ def register_image_usage_report_menu_item():
         "Image usage report",
         reverse("image_usage_report"),
         icon_name=ImageUsageReport.header_icon,
-        order=700,
+        order=1250,  # Place this after Page types usage report
     )
 
 


### PR DESCRIPTION
This is a report for identifying images that are not currently in use. Right now it is very basic - a list of all images on the site and a count of how often they are used. There are links to the image usage page and to the image edit where one can delete the image. It is usuable in its current condition but if anyone wants to extend this report, it might be useful to add a FilterSet that allows filtering by collection and/or by used / not used. 