### PR TITLE
Update Pagination in Blog Index Page

### DIFF
--- a/wagtailio/blog/models.py
+++ b/wagtailio/blog/models.py
@@ -57,12 +57,32 @@ class BlogIndexPage(Page, SocialMediaMixin, CrossPageMixin):
         except EmptyPage:
             posts = None
 
+        #Generate Pagination Sequence
+        current_page = posts.number
+        total_pages = last_page = paginator.num_pages
+        pagination_sequence = []
+
+        if total_pages <= 7:
+            pagination_sequence = list(paginator.page_range)
+        else:
+            if current_page <= 3:
+                pagination_sequence.extend([1, 2, 3, 4, 5, 0, last_page])
+            elif current_page >= total_pages - 2:
+                pagination_sequence.extend([1, 0, last_page -4, last_page -3, last_page - 2, last_page - 1, last_page])
+            else:
+                pagination_sequence.extend([1, 0, current_page - 2, current_page - 1, current_page, current_page + 1, current_page +2, 0, last_page])
+                if current_page + 3 == last_page:
+                    pagination_sequence.pop(-2)
+                if current_page - 3 == 1:
+                    pagination_sequence.pop(1)
+
         return render(
             request,
             self.template,
             {
                 "page": self,
                 "posts": posts,
+                "pagination_sequence": pagination_sequence,
                 "featured_posts": [post.page for post in self.featured_posts.all()],
                 "categories": Category.objects.filter(
                     pk__in=models.Subquery(self.posts.values("category"))

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_index_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_index_page.html
@@ -83,9 +83,23 @@
                 </a>
             {% endif %}
 
-            <span class="pagination__page-count mini-meta">
-                Page {{ posts.number }} of {{ posts.paginator.num_pages }}
-            </span>
+            <ul class="pagination__sequence">
+                {% for num in pagination_sequence %}
+                    {% if num == 0 %}
+                        <li>
+                            <span class="pagination__ellipsis">...</span>
+                        </li>
+                    {% elif num == posts.number %}
+                        <li>
+                            <a href="?page={{ num }}" class="pagination__page-number pagination__page-number--current">{{ num }}</a>
+                        </li>
+                    {% else %}
+                        <li>
+                            <a href="?page={{ num }}" class="pagination__page-number">{{ num }}</a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
 
             {% if posts.has_next %}
                 <a href="?page={{ posts.next_page_number }}" class="pagination__next button">

--- a/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_index_page.html
+++ b/wagtailio/project_styleguide/templates/patterns/pages/blog/blog_index_page.html
@@ -75,27 +75,31 @@
         <div class="pagination">
             {% if posts.has_previous %}
                 <a href="?page={{ posts.previous_page_number }}" class="pagination__previous button button--reverse">
-                    <p class="button__text">
-                        Previous
-                        <span class="u-sr-only">- Go to page {{ posts.previous_page_number}}</span>
-                    </p>
+                    <p class="button__text">Previous</p>
+                    <span class="u-sr-only">- Go to page {{ posts.previous_page_number}}</span>
                     <svg class="arrow" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
                 </a>
             {% endif %}
 
-            <ul class="pagination__sequence">
+            <ul class="pagination__sequence" aria-label="Pagination Sequence">
                 {% for num in pagination_sequence %}
                     {% if num == 0 %}
                         <li>
-                            <span class="pagination__ellipsis">...</span>
+                            <span class="pagination__ellipsis" aria-hidden="true">...</span>
                         </li>
                     {% elif num == posts.number %}
                         <li>
-                            <a href="?page={{ num }}" class="pagination__page-number pagination__page-number--current">{{ num }}</a>
+                            <a href="?page={{ num }}" class="pagination__page-number pagination__page-number--current" aria-current="page">
+                                <span class="u-sr-only">Page </span>
+                                {{ num }}
+                            </a>
                         </li>
                     {% else %}
                         <li>
-                            <a href="?page={{ num }}" class="pagination__page-number">{{ num }}</a>
+                            <a href="?page={{ num }}" class="pagination__page-number">
+                                <span class="u-sr-only">Page </span>
+                                {{ num }}
+                            </a>
                         </li>
                     {% endif %}
                 {% endfor %}
@@ -103,10 +107,8 @@
 
             {% if posts.has_next %}
                 <a href="?page={{ posts.next_page_number }}" class="pagination__next button">
-                    <p class="button__text">
-                        Next
-                        <span class="u-sr-only">- Go to page {{ posts.next_page_number}}</span>
-                    </p>
+                    <p class="button__text">Next</p>
+                    <span class="u-sr-only">- Go to page {{ posts.next_page_number}}</span>
                     <svg class="arrow" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
                 </a>
             {% endif %}

--- a/wagtailio/static/sass/components/_pagination.scss
+++ b/wagtailio/static/sass/components/_pagination.scss
@@ -6,12 +6,15 @@
     @include sf-spacing(2);
     grid-column: 2 / span 2;
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
     gap: 20px;
     align-items: center;
 
+    @include media-query(smallonly) {
+        flex-direction: column;
+    }
+
     @include media-query(medium) {
-        display: block;
         grid-column: 2 / span 3;
     }
 
@@ -19,22 +22,40 @@
         grid-column: 2 / span 5;
     }
 
-    &__previous {
-        padding: 10px;
-
-        @include media-query(medium) {
-            margin-right: 20px;
-            padding: 15px 30px;
-        }
-    }
-
+    &__previous,
     &__next {
         padding: 10px;
 
         @include media-query(medium) {
-            padding: 15px 30px;
-            margin-left: 20px;
+            .button__text{
+                display: none;
+            }
         }
+
+        @include media-query(large) {
+            padding: 15px;
+        }
+    }
+
+    &__sequence {
+        display: flex;
+        gap: 3px;
+        list-style: none;
+        align-items: center;
+    }
+
+    &__page-number {
+        text-decoration: none;
+        font-size: 1.25rem;
+        padding: 10px;
+
+        &--current {
+            color: var(--color--text);;
+        }
+    }
+
+    &__ellipsis {
+        font-size: 1.25rem;
     }
 
     &--showcase {
@@ -44,7 +65,7 @@
         align-items: center;
         flex-direction: row;
 
-        @include media-query(smallonly){
+        @include media-query(smallonly) {
             flex-direction: column;
             #{$root}__previous,
                 #{$root}__next {


### PR DESCRIPTION
**Description:**
---
This PR updates the pagination system on the blog index page, as referenced in #349. It introduces pagination logic that aligns with the conventions outlined in the GSC docs.

 **Pagination Sequence Logic:**
---
  - If there are 7 or fewer pages in total, all pages are displayed without ellipses (`...`).
  - For more than 7 pages:
    - Displays up to 7 pages at a time, with ellipses (`...`) when necessary.
    - Displays 6 pages when the current page is near either end of the page range.
    - Always displays at least 2 page numbers to the left and right of the current page, if they exist.

 **Screenshots:**
---
<details><summary>Pagination Sequence on different pages</summary>
<p>

For more than 7 pages in total:
![Screenshot from 2025-03-23 02-12-44 (1)](https://github.com/user-attachments/assets/1a2bf34d-a39b-4aeb-9fea-d3b9667e35fe)
![Screenshot from 2025-03-23 02-12-38](https://github.com/user-attachments/assets/aee4360e-4e0e-450a-a172-063920d1e6f2)
![Screenshot from 2025-03-23 02-11-54](https://github.com/user-attachments/assets/5a093103-38ae-42bb-9b52-1ede958b9cba)
![Screenshot from 2025-03-23 02-11-43](https://github.com/user-attachments/assets/90c0f057-3c8e-49ed-a5dc-cf075e750a85)
![Screenshot from 2025-03-23 02-11-21](https://github.com/user-attachments/assets/148addab-3270-455a-8059-f96dc88e21cf)
For 7 or fewer total pages:
![Screenshot from 2025-03-23 02-10-01](https://github.com/user-attachments/assets/907481cc-6a30-40bc-93ba-0a73466535fe)
![Screenshot from 2025-03-23 09-03-04](https://github.com/user-attachments/assets/8a59f484-ab31-4552-8adb-1fbb91372c62)

</p>
</details> 

<details><summary>Pagination on Small devices</summary>
<p>

![Screenshot from 2025-03-23 02-16-47 (2)](https://github.com/user-attachments/assets/7f2fb716-d680-4bc1-a5ee-aaa64e51b1bf)

</p>
</details> 



