### PR TITLE
Style adjustment for sponsor heading.

### DIFF
--- a/wagtailio/static/sass/layout/_space-page.scss
+++ b/wagtailio/static/sass/layout/_space-page.scss
@@ -467,7 +467,9 @@
   line-height: 150%;
   font-family: $font--primary;
   color: $color--off-black;
-  text-align: center;
+  text-align: center; 
+  display: flex;
+  justify-content: center;
 }
 
 .sponsor-type {


### PR DESCRIPTION
There is a style for the sponsor section heading that is misbehaving in the desktop version of the Wagtail Space landing page. It is not centered in the desktop display and it should be. This is a quick fix to make the text center properly.