### PR TITLE
Fix sponsor links when there is no link

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/sponsor_block/sponsor_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/sponsor_block/sponsor_block.html
@@ -3,7 +3,12 @@
     <p class="sponsor-type">{{ value.sponsor_type }}</p>
     <div class="sponsor-logo">
         {% for logo in value.sponsor_logo %}
-            <a href="{{ value.sponsor_link }}">{% image logo width-500 %}</a>
+            {% image logo width-500 as logo_img %}
+            {% if value.sponsor_link %}
+                <a href="{{ value.sponsor_link }}">{{ logo_img }}</a>
+            {% else %}
+                {{ logo_img }}
+            {% endif %}
         {% endfor %}
     </div>
 </div>


### PR DESCRIPTION
Follow-up to #530. In addition we should also ideally not be using `ImageBlock`, as it’s mandatory for all images to have alt text in this context (otherwise screen reader users can’t know who the sponsors are).