### PR TITLE
fix: correct template syntax in comparison_table_block.html

### DIFF
--- a/wagtailio/project_styleguide/templates/patterns/components/streamfields/comparison_table_block/comparison_table_block.html
+++ b/wagtailio/project_styleguide/templates/patterns/components/streamfields/comparison_table_block/comparison_table_block.html
@@ -26,7 +26,7 @@
                             </th>
                         {% else %}
                             <td>
-                                { block %}
+                                {{ block }}
                             </td>
                         {% endif %}
                     {% endfor %}


### PR DESCRIPTION
Fixed the typo for rendering variable.
This PR addresses #557 